### PR TITLE
Sorting

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,3 +4,6 @@ target_include_directories(nanobench PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(brevzin-benchmark brevzin_benchmark.cpp)
 target_link_libraries(brevzin-benchmark PUBLIC nanobench flux)
+
+add_executable(sort-benchmark sort_benchmark.cpp)
+target_link_libraries(sort-benchmark PUBLIC nanobench flux)

--- a/benchmark/sort_benchmark.cpp
+++ b/benchmark/sort_benchmark.cpp
@@ -1,0 +1,89 @@
+
+#include "nanobench.h"
+
+#include <flux.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+
+namespace an = ankerl::nanobench;
+
+static constexpr int test_sz = 100'000;
+
+template <typename SortFn, typename Vec>
+static void test_sort(const char* name, SortFn, const Vec& vec, an::Bench& bench)
+{
+    bench.run(name, [&] {
+        Vec copy = vec;
+        SortFn{}(copy);
+        bench.doNotOptimizeAway(copy);
+    });
+}
+
+int main()
+{
+    {
+        std::vector<int> vec(test_sz);
+        std::mt19937 gen{std::random_device{}()};
+        std::uniform_int_distribution dist(0, test_sz);
+        std::generate(vec.begin(), vec.end(), [&] { return dist(gen); });
+
+        auto bench = an::Bench().relative(true).minEpochIterations(10);
+
+        test_sort("random ints (std)", std::ranges::sort, vec, bench);
+        test_sort("random ints (flux)", flux::sort, vec, bench);
+    }
+
+    {
+        std::vector<int> vec(test_sz);
+        std::iota(vec.begin(), vec.end(), 0);
+        auto bench = an::Bench().relative(true).minEpochIterations(10);
+        test_sort("sorted ints (std)", std::ranges::sort, vec, bench);
+        test_sort("sorted ints (flux)", flux::sort, vec, bench);
+    }
+
+    {
+        std::vector<int> vec(test_sz);
+        std::iota(vec.begin(), vec.end(), 0);
+        std::ranges::reverse(vec);
+        auto bench = an::Bench().relative(true).minEpochIterations(10);
+        test_sort("reverse sorted ints (std)", std::ranges::sort, vec, bench);
+        test_sort("reverse sorted ints (flux)", flux::sort, vec, bench);
+    }
+
+    {
+        std::vector<int> vec(test_sz);
+        std::iota(vec.begin(), vec.begin() + test_sz/2, 0);
+        std::iota(vec.begin() + test_sz/2, vec.end(), 0);
+        std::reverse(vec.begin() + test_sz/2, vec.end());
+
+        auto bench = an::Bench().relative(true).minEpochIterations(10);
+        test_sort("organpipe ints (std)", std::ranges::sort, vec, bench);
+        test_sort("organpipe ints (flux)", flux::sort, vec, bench);
+    }
+
+    {
+        std::vector<double> vec(test_sz);
+        std::mt19937 gen{std::random_device{}()};
+        std::uniform_real_distribution<double> dist(0, test_sz);
+        std::generate(vec.begin(), vec.end(), [&] { return dist(gen); });
+
+        auto bench = an::Bench().relative(true).minEpochIterations(10);
+
+        test_sort("random doubles (std)", std::ranges::sort, vec, bench);
+        test_sort("random doubles (flux)", flux::sort, vec, bench);
+    }
+
+    {
+        std::vector<std::string> vec(test_sz);
+        std::mt19937 gen{std::random_device{}()};
+        std::uniform_int_distribution dist(0, test_sz);
+        std::generate(vec.begin(), vec.end(), [&] { return std::to_string(dist(gen)); });
+
+        auto bench = an::Bench().relative(true);
+
+        test_sort("random strings (std)", std::ranges::sort, vec, bench);
+        test_sort("random strings (flux)", flux::sort, vec, bench);
+    }
+}

--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -29,6 +29,7 @@
 #include <flux/op/slice.hpp>
 #include <flux/op/split.hpp>
 #include <flux/op/split_string.hpp>
+#include <flux/op/sort.hpp>
 #include <flux/op/swap_elements.hpp>
 #include <flux/op/take.hpp>
 #include <flux/op/take_while.hpp>

--- a/include/flux/core/lens_base.hpp
+++ b/include/flux/core/lens_base.hpp
@@ -182,7 +182,7 @@ public:
     constexpr auto view() const&& requires sequence<Derived const>;
 
     /*
-     * Folds of various kinds
+     * Algorithms
      */
 
     /// Returns `true` if every element of the sequence satisfies the predicate
@@ -254,6 +254,13 @@ public:
         requires std::weakly_incrementable<Iter> &&
                  std::indirectly_writable<Iter, element_t<Derived>>
     constexpr auto output_to(Iter iter) -> Iter;
+
+    template <typename Cmp = std::less<>, typename Proj = std::identity>
+        requires random_access_sequence<Derived> &&
+                 bounded_sequence<Derived> &&
+                 detail::element_swappable_with<Derived, Derived> &&
+                 std::predicate<Cmp&, projected_t<Proj, Derived>, projected_t<Proj, Derived>>
+    constexpr void sort(Cmp cmp = {}, Proj proj = {});
 
     template <typename Container, typename... Args>
     constexpr auto to(Args&&... args) -> Container;

--- a/include/flux/op/detail/heap_ops.hpp
+++ b/include/flux/op/detail/heap_ops.hpp
@@ -1,0 +1,162 @@
+// flux/op/detail/heap_sift.hpp
+//
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// cmcstl2 - A concept-enabled C++ standard library
+//
+//  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2015
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/caseycarter/cmcstl2
+//
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FLUX_OP_DETAIL_HEAP_OPS_HPP_INCLUDED
+#define FLUX_OP_DETAIL_HEAP_OPS_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+namespace flux::detail {
+
+template <typename Seq, typename Comp, typename Proj>
+constexpr void sift_up_n(Seq& seq, distance_t<Seq> n, Comp& comp, Proj& proj)
+{
+    cursor_t<Seq> first = flux::first(seq);
+
+    if (n > 1) {
+        cursor_t<Seq> last = flux::next(seq, first, n);
+        n = (n - 2) / 2;
+        cursor_t<Seq> i = first + n;
+        if (std::invoke(comp, std::invoke(proj, read_at(seq, i)),
+                         std::invoke(proj, read_at(seq, dec(seq, last))))) {
+            value_t<Seq> v = move_at(seq, last);
+            do {
+                read_at(seq, last) = move_at(seq, i);
+                last = i;
+                if (n == 0) {
+                    break;
+                }
+                n = (n - 1) / 2;
+                i = next(seq, first, n);
+            } while (std::invoke(comp, std::invoke(proj, read_at(seq, i)),
+                                  std::invoke(proj, v)));
+            read_at(seq, last) = std::move(v);
+        }
+    }
+}
+
+template <typename Seq, typename Comp, typename Proj>
+constexpr void sift_down_n(Seq& seq, distance_t<Seq> n, cursor_t<Seq> start,
+                           Comp& comp, Proj& proj)
+{
+    cursor_t<Seq> first = flux::first(seq);
+
+    // left-child of start is at 2 * start + 1
+    // right-child of start is at 2 * start + 2
+    //auto child = start - first;
+    auto child = flux::distance(seq, first, start);
+
+    if (n < 2 || (n - 2) / 2 < child) {
+        return;
+    }
+
+    child = 2 * child + 1;
+    cursor_t<Seq> child_i = flux::next(seq, first, child);
+
+    if ((child + 1) < n && std::invoke(comp, std::invoke(proj, read_at(seq, child_i)),
+                                        std::invoke(proj, read_at(seq, next(seq, child_i))))) {
+        // right-child exists and is greater than left-child
+        flux::inc(seq, child_i);
+        ++child;
+    }
+
+    // check if we are in heap-order
+    if (std::invoke(comp, std::invoke(proj, read_at(seq, child_i)),
+                     std::invoke(proj, read_at(seq, start)))) {
+        // we are, start is larger than its largest child
+        return;
+    }
+
+    value_t<Seq> top = move_at(seq, start);
+    do {
+        // we are not in heap-order, swap the parent with it's largest child
+        read_at(seq, start) = move_at(seq, child_i);
+        //*start = nano::iter_move(child_i);
+        start = child_i;
+
+        if ((n - 2) / 2 < child) {
+            break;
+        }
+
+        // recompute the child based off of the updated parent
+        child = 2 * child + 1;
+        child_i = next(seq, first, child); //child_i = first + child;
+
+        if ((child + 1) < n &&
+            std::invoke(comp, std::invoke(proj, read_at(seq, child_i)),
+                         std::invoke(proj, read_at(seq, next(seq, child_i))))) {
+            // right-child exists and is greater than left-child
+            inc(seq, child_i);
+            ++child;
+        }
+
+        // check if we are in heap-order
+    } while (!std::invoke(comp, std::invoke(proj, read_at(seq, child_i)),
+                           std::invoke(proj, top)));
+    read_at(seq, start) = std::move(top);
+}
+
+template <sequence Seq, typename Comp, typename Proj >
+constexpr void make_heap(Seq& seq, Comp& comp, Proj& proj)
+{
+    distance_t<Seq> n = flux::size(seq);
+    auto first = flux::first(seq);
+
+    if (n > 1) {
+        for (auto start = (n - 2) / 2; start >= 0; --start) {
+            detail::sift_down_n(seq, n, flux::next(seq, first, start), comp, proj);
+        }
+    }
+}
+
+template <sequence Seq, typename Comp, typename Proj>
+constexpr void pop_heap(Seq& seq, distance_t<Seq> n, Comp& comp, Proj& proj)
+{
+    auto first = flux::first(seq);
+    if (n > 1) {
+        swap_at(seq, first, next(seq, first, n - 1));
+        detail::sift_down_n(seq, n - 1, first, comp, proj);
+    }
+}
+
+template <sequence Seq, typename Comp, typename Proj>
+constexpr void sort_heap(Seq& seq, Comp& comp, Proj& proj)
+{
+    auto n = flux::size(seq);
+
+    if (n < 2) {
+        return;
+    }
+
+    for (auto i = n; i > 1; --i) {
+        pop_heap(seq, i, comp, proj);
+    }
+}
+
+}
+
+#endif

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -60,8 +60,8 @@ constexpr int log2(T n)
 }
 
 // Sorts [begin, end) using insertion sort with the given comparison function.
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
-constexpr void insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
+constexpr void insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp)
 {
     using T = value_t<Seq>;
 
@@ -75,18 +75,15 @@ constexpr void insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& co
 
         // Compare first so we can avoid 2 moves for an element already
         // positioned correctly.
-        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
-                         std::invoke(proj, read_at(seq, sift_1)))) {
+        if (comp(read_at(seq, sift), read_at(seq, sift_1))) {
             T tmp = move_at(seq, sift);
 
             do {
                 read_at(seq, sift) = move_at(seq, sift_1);
                 dec(seq, sift);
-            } while (sift != begin &&
-                     std::invoke(comp, std::invoke(proj, tmp),
-                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+            } while (sift != begin && comp(tmp, read_at(seq, dec(seq, sift_1))));
 
-              read_at(seq, sift) = std::move(tmp);
+            read_at(seq, sift) = std::move(tmp);
         }
     }
 }
@@ -95,9 +92,9 @@ constexpr void insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& co
 // Assumes
 // *(begin - 1) is an element smaller than or equal to any element in [begin,
 // end).
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
 constexpr void unguarded_insertion_sort(Seq& seq, Cur const begin, Cur const end,
-                                        Comp& comp, Proj& proj)
+                                        Comp& comp)
 {
     using T = value_t<Seq>;
 
@@ -111,15 +108,13 @@ constexpr void unguarded_insertion_sort(Seq& seq, Cur const begin, Cur const end
 
         // Compare first so we can avoid 2 moves for an element already
         // positioned correctly.
-        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
-                         std::invoke(proj, read_at(seq, sift_1)))) {
+        if (comp(read_at(seq, sift), read_at(seq, sift_1))) {
             T tmp = move_at(seq, sift);
 
             do {
                 read_at(seq, sift) = move_at(seq, sift_1);
                 dec(seq, sift);
-            } while (std::invoke(comp, std::invoke(proj, tmp),
-                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+            } while (comp(tmp, read_at(seq, dec(seq, sift_1))));
 
             read_at(seq, sift) = std::move(tmp);
         }
@@ -129,8 +124,8 @@ constexpr void unguarded_insertion_sort(Seq& seq, Cur const begin, Cur const end
 // Attempts to use insertion sort on [begin, end). Will return false if more
 // than partial_insertion_sort_limit elements were moved, and abort sorting.
 // Otherwise it will successfully sort and return true.
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
-constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
+constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp)
 {
     using T = value_t<Seq>;
 
@@ -150,16 +145,13 @@ constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, 
 
         // Compare first so we can avoid 2 moves for an element already
         // positioned correctly.
-        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
-                         std::invoke(proj, read_at(seq, sift_1)))) {
+        if (comp(read_at(seq, sift), read_at(seq, sift_1))) {
             T tmp = move_at(seq, sift);
 
             do {
                 read_at(seq, sift) = move_at(seq, sift_1);
                 dec(seq, sift);
-            } while (sift != begin &&
-                     std::invoke(comp, std::invoke(proj, tmp),
-                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+            } while (sift != begin && comp(tmp, read_at(seq, dec(seq, sift_1))));
 
             read_at(seq, sift) = std::move(tmp);
             limit += distance(seq, sift, cur);
@@ -169,21 +161,21 @@ constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, 
     return true;
 }
 
-template <sequence Seq, typename Comp, typename Proj>
-constexpr void sort2(Seq& seq, cursor_t<Seq> a, cursor_t<Seq> b, Comp& comp, Proj& proj)
+template <sequence Seq, typename Comp>
+constexpr void sort2(Seq& seq, cursor_t<Seq> a, cursor_t<Seq> b, Comp& comp)
 {
-    if (std::invoke(comp, std::invoke(proj, read_at(seq, b)), std::invoke(proj, read_at(seq, a)))) {
+    if (comp(read_at(seq, b), read_at(seq, a))) {
         swap_at(seq, a, b);
     }
 }
 
 // Sorts the elements *a, *b and *c using comparison function comp.
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
-constexpr void sort3(Seq& seq, Cur a, Cur b, Cur c, Comp& comp, Proj& proj)
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
+constexpr void sort3(Seq& seq, Cur a, Cur b, Cur c, Comp& comp)
 {
-    sort2(seq, a, b, comp, proj);
-    sort2(seq, b, c, comp, proj);
-    sort2(seq, a, b, comp, proj);
+    sort2(seq, a, b, comp);
+    sort2(seq, b, c, comp);
+    sort2(seq, a, b, comp);
 }
 
 #if 0
@@ -432,9 +424,9 @@ constexpr std::pair<I, bool> partition_right_branchless(I begin, I end,
 // position of the pivot after partitioning and whether the passed sequence
 // already was correctly partitioned. Assumes the pivot is a median of at least
 // 3 elements and that [begin, end) is at least insertion_sort_threshold long.
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
 constexpr std::pair<cursor_t<Seq>, bool>
-partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp)
 {
     using T = value_t<Seq>;
 
@@ -446,19 +438,16 @@ partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj
 
     // Find the first element greater than or equal than the pivot (the median
     // of 3 guarantees this exists).
-    while (std::invoke(comp, std::invoke(proj, read_at(seq, inc(seq, first))),
-                        std::invoke(proj, pivot))) {
+    while (comp(read_at(seq, inc(seq, first)), pivot)) {
     }
 
     // Find the first element strictly smaller than the pivot. We have to guard
     // this search if there was no element before *first.
     if (prev(seq, first) == begin) {
-        while (first < last && !std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
-                                             std::invoke(proj, pivot))) {
+        while (first < last && !comp(read_at(seq, dec(seq, last)), pivot)) {
         }
     } else {
-        while (!std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
-                             std::invoke(proj, pivot))) {
+        while (!comp(read_at(seq, dec(seq, last)), pivot)) {
         }
     }
 
@@ -471,11 +460,9 @@ partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj
     // iteration is special-cased above.
     while (first < last) {
         swap_at(seq, first, last);
-        while (std::invoke(comp, std::invoke(proj, read_at(seq, inc(seq, first))),
-                            std::invoke(proj, pivot)))
+        while (comp(read_at(seq, inc(seq, first)), pivot))
             ;
-        while (!std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
-                             std::invoke(proj, pivot)))
+        while (!comp(read_at(seq, dec(seq, last)), pivot))
             ;
     }
 
@@ -492,8 +479,8 @@ partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj
 // sequence already was partitioned. Since this is rarely used (the many equal
 // case), and in that case pdqsort already has O(n) performance, no block
 // quicksort is applied here for simplicity.
-template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
-constexpr cursor_t<Seq> partition_left(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+template <sequence Seq, typename Comp, typename Cur = cursor_t<Seq>>
+constexpr cursor_t<Seq> partition_left(Seq& seq, Cur const begin, Cur const end, Comp& comp)
 {
     using T = value_t<Seq>;
 
@@ -501,27 +488,22 @@ constexpr cursor_t<Seq> partition_left(Seq& seq, Cur const begin, Cur const end,
     cursor_t<Seq> first = begin;
     cursor_t<Seq> last = end;
 
-    while (std::invoke(comp, std::invoke(proj, pivot),
-                        std::invoke(proj, read_at(seq, dec(seq, last)))))
+    while (comp(pivot, read_at(seq, dec(seq, last))))
         ;
 
     if (next(seq, last) == end) {
-        while (first < last && !std::invoke(comp, std::invoke(proj, pivot),
-                                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+        while (first < last && !comp(pivot, read_at(seq, inc(seq, first))))
             ;
     } else {
-        while (!std::invoke(comp, std::invoke(proj, pivot),
-                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+        while (!comp(pivot, read_at(seq, inc(seq, first))))
             ;
     }
 
     while (first < last) {
         swap_at(seq, first, last);
-        while (std::invoke(comp, std::invoke(proj, pivot),
-                            std::invoke(proj, read_at(seq, dec(seq, last)))))
+        while (comp(pivot, read_at(seq, dec(seq, last))))
             ;
-        while (!std::invoke(comp, std::invoke(proj, pivot),
-                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+        while (!comp(pivot, read_at(seq, inc(seq, first))))
             ;
     }
 
@@ -532,9 +514,9 @@ constexpr cursor_t<Seq> partition_left(Seq& seq, Cur const begin, Cur const end,
     return pivot_pos;
 }
 
-template <bool Branchless, typename Seq, typename Comp, typename Proj,
+template <bool Branchless, typename Seq, typename Comp,
           typename Cur = cursor_t<Seq>>
-constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj,
+constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp,
                             int bad_allowed, bool leftmost = true)
 {
     //using diff_t = iter_difference_t<I>
@@ -547,9 +529,9 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
         // Insertion sort is faster for small arrays.
         if (size < pdqsort_insertion_sort_threshold) {
             if (leftmost) {
-                insertion_sort(seq, begin, end, comp, proj);
+                insertion_sort(seq, begin, end, comp);
             } else {
-                unguarded_insertion_sort(seq, begin, end, comp, proj);
+                unguarded_insertion_sort(seq, begin, end, comp);
             }
             return;
         }
@@ -557,13 +539,13 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
         // Choose pivot as median of 3 or pseudomedian of 9.
         diff_t s2 = size / 2;
         if (size > pdqsort_ninther_threshold) {
-            sort3(seq, begin, next(seq, begin, s2), prev(seq, end), comp, proj);
-            sort3(seq, next(seq, begin), next(seq, begin, s2 - 1), next(seq, end, -2), comp, proj);
-            sort3(seq, next(seq, begin, 2), next(seq, begin, s2 + 1), next(seq, end, -3), comp, proj);
-            sort3(seq, next(seq, begin, s2 - 1), next(seq, begin, s2), next(seq, begin, s2 + 1), comp, proj);
+            sort3(seq, begin, next(seq, begin, s2), prev(seq, end), comp);
+            sort3(seq, next(seq, begin), next(seq, begin, s2 - 1), next(seq, end, -2), comp);
+            sort3(seq, next(seq, begin, 2), next(seq, begin, s2 + 1), next(seq, end, -3), comp);
+            sort3(seq, next(seq, begin, s2 - 1), next(seq, begin, s2), next(seq, begin, s2 + 1), comp);
             swap_at(seq, begin, next(seq, begin, s2));
         } else {
-            sort3(seq, next(seq, begin, s2), begin, prev(seq, end), comp, proj);
+            sort3(seq, next(seq, begin, s2), begin, prev(seq, end), comp);
         }
 
         // If *(begin - 1) is the end of the right partition of a previous
@@ -572,9 +554,8 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
         // *(begin - 1) we change strategy, putting equal elements in the left
         // partition, greater elements in the right partition. We do not have to
         // recurse on the left partition, since it's sorted (all equal).
-        if (!leftmost && !std::invoke(comp, std::invoke(proj, read_at(seq, prev(seq, begin))),
-                                       std::invoke(proj, read_at(seq, begin)))) {
-            begin = next(seq, partition_left(seq, begin, end, comp, proj));
+        if (!leftmost && !comp(read_at(seq, prev(seq, begin)), read_at(seq, begin))) {
+            begin = next(seq, partition_left(seq, begin, end, comp));
             continue;
         }
 
@@ -585,7 +566,7 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
                        : partition_right(begin, end, comp, proj);
         I pivot_pos = part_result.first;
         bool already_partitioned = part_result.second;*/
-        auto [pivot_pos, already_partitioned] = partition_right(seq, begin, end, comp, proj);
+        auto [pivot_pos, already_partitioned] = partition_right(seq, begin, end, comp);
 
         // Check for a highly unbalanced partition.
         diff_t l_size = distance(seq, begin, pivot_pos);
@@ -599,8 +580,8 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
             // guarantee O(n log n).
             if (--bad_allowed == 0) {
                 auto view = flux::view(slice(seq, begin, end));
-                std::ranges::make_heap(view, comp, proj);
-                std::ranges::sort_heap(view, comp, proj);
+                std::ranges::make_heap(view, comp);
+                std::ranges::sort_heap(view, comp);
                 return;
             }
 
@@ -631,14 +612,14 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj
             // If we were decently balanced and we tried to sort an already
             // partitioned sequence try to use insertion sort.
             if (already_partitioned &&
-                partial_insertion_sort(seq, begin, pivot_pos, comp, proj) &&
-                partial_insertion_sort(seq, pivot_pos + 1, end, comp, proj))
+                partial_insertion_sort(seq, begin, pivot_pos, comp) &&
+                partial_insertion_sort(seq, pivot_pos + 1, end, comp))
                 return;
         }
 
         // Sort the left partition first using recursion and do tail recursion
         // elimination for the right-hand partition.
-        detail::pdqsort_loop<Branchless>(seq, begin, pivot_pos, comp, proj,
+        detail::pdqsort_loop<Branchless>(seq, begin, pivot_pos, comp,
                                          bad_allowed, leftmost);
         begin = next(seq, pivot_pos);
         leftmost = false;
@@ -658,11 +639,20 @@ constexpr void pdqsort(Seq& seq, Comp& comp, Proj& proj)
          std::is_arithmetic_v<iter_value_t<I>>::value
 */
     constexpr bool Branchless = false;
+
+    auto comparator = [&comp, &proj](auto&& lhs, auto&& rhs) {
+        if constexpr (std::same_as<Proj, std::identity>) {
+            return std::invoke(comp, FLUX_FWD(lhs), FLUX_FWD(rhs));
+        } else {
+            return std::invoke(comp, std::invoke(proj, FLUX_FWD(lhs)),
+                               std::invoke(proj, FLUX_FWD(rhs)));
+        }
+    };
+
     detail::pdqsort_loop<Branchless>(seq,
                                      first(seq),
                                      last(seq),
-                                     comp,
-                                     proj,
+                                     comparator,
                                      detail::log2(size(seq)));
 }
 

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -13,7 +13,8 @@
 
 #include <flux/core.hpp>
 #include <flux/op/slice.hpp>
-#include <flux/ranges/view.hpp>
+
+#include <flux/op/detail/heap_ops.hpp>
 
 namespace flux {
 
@@ -561,9 +562,10 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp,
             // If we had too many bad partitions, switch to heapsort to
             // guarantee O(n log n).
             if (--bad_allowed == 0) {
-                auto view = flux::view(slice(seq, begin, end));
-                std::ranges::make_heap(view, comp);
-                std::ranges::sort_heap(view, comp);
+                auto subseq = flux::slice(seq, begin, end);
+                auto id = std::identity{};
+                detail::make_heap(subseq, comp, id);
+                detail::sort_heap(subseq, comp, id);
                 return;
             }
 

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -349,7 +349,7 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
     if (unknown_left && !num_l) {
         start_l = 0;
         Cur cur = first;
-        for (unsigned char i = 0; i < l_size;) {
+        for (unsigned char i = 0; static_cast<distance_t<Seq>>(i) < l_size;) {
             offsets_l[num_l] = i++;
             num_l += !comp(read_at(seq, cur), pivot);
             inc(seq, cur);
@@ -358,7 +358,7 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
     if (unknown_left && !num_r) {
         start_r = 0;
         Cur cur = last;
-        for (unsigned char i = 0; i < r_size;) {
+        for (unsigned char i = 0; static_cast<distance_t<Seq>>(i) < r_size;) {
             offsets_r[num_r] = ++i;
             num_r += comp(read_at(seq, dec(seq, cur)), pivot);
         }

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -597,7 +597,7 @@ constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp,
             // partitioned sequence try to use insertion sort.
             if (already_partitioned &&
                 partial_insertion_sort(seq, begin, pivot_pos, comp) &&
-                partial_insertion_sort(seq, pivot_pos + 1, end, comp))
+                partial_insertion_sort(seq, flux::next(seq, pivot_pos), end, comp))
                 return;
         }
 

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -1,0 +1,673 @@
+// flux/op/detail/pqdsort.hpp
+//
+// Copyright Orson Peters 2017.
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Modified from Boost.Sort by Orson Peters
+// https://github.com/boostorg/sort/blob/develop/include/boost/sort/pdqsort/pdqsort.hpp
+
+#ifndef FLUX_OP_DETAIL_PDQSORT_HPP_INCLUDED
+#define FLUX_OP_DETAIL_PDQSORT_HPP_INCLUDED
+
+#include <flux/core.hpp>
+#include <flux/op/slice.hpp>
+#include <flux/ranges/view.hpp>
+
+namespace flux {
+
+namespace detail {
+
+// Partitions below this size are sorted using insertion sort.
+inline constexpr int pdqsort_insertion_sort_threshold = 24;
+
+// Partitions above this size use Tukey's ninther to select the pivot.
+inline constexpr int pdqsort_ninther_threshold = 128;
+
+// When we detect an already sorted partition, attempt an insertion sort that
+// allows this amount of element moves before giving up.
+inline constexpr int pqdsort_partial_insertion_sort_limit = 8;
+
+// Must be multiple of 8 due to loop unrolling, and < 256 to fit in unsigned
+// char.
+inline constexpr int pdqsort_block_size = 64;
+
+// Cacheline size, assumes power of two.
+inline constexpr int pdqsort_cacheline_size = 64;
+
+template <typename T>
+inline constexpr bool is_default_compare_v = false;
+
+template <typename T>
+inline constexpr bool is_default_compare_v<std::less<T>> = true;
+template <typename T>
+inline constexpr bool is_default_compare_v<std::greater<T>> = true;
+template <>
+inline constexpr bool is_default_compare_v<std::ranges::less> = true;
+template <>
+inline constexpr bool is_default_compare_v<std::ranges::greater> = true;
+
+
+// Returns floor(log2(n)), assumes n > 0.
+template <class T>
+constexpr int log2(T n)
+{
+    int log = 0;
+    while (n >>= 1)
+        ++log;
+    return log;
+}
+
+// Sorts [begin, end) using insertion sort with the given comparison function.
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr void insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+{
+    using T = value_t<Seq>;
+
+    if (begin == end) {
+        return;
+    }
+
+    for (auto cur = next(seq, begin); cur != end; inc(seq, cur)) {
+        cursor_t<Seq> sift = cur;
+        cursor_t<Seq> sift_1 = prev(seq, cur);
+
+        // Compare first so we can avoid 2 moves for an element already
+        // positioned correctly.
+        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
+                         std::invoke(proj, read_at(seq, sift_1)))) {
+            T tmp = move_at(seq, sift);
+
+            do {
+                read_at(seq, sift) = move_at(seq, sift_1);
+                dec(seq, sift);
+            } while (sift != begin &&
+                     std::invoke(comp, std::invoke(proj, tmp),
+                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+
+              read_at(seq, sift) = std::move(tmp);
+        }
+    }
+}
+
+// Sorts [begin, end) using insertion sort with the given comparison function.
+// Assumes
+// *(begin - 1) is an element smaller than or equal to any element in [begin,
+// end).
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr void unguarded_insertion_sort(Seq& seq, Cur const begin, Cur const end,
+                                        Comp& comp, Proj& proj)
+{
+    using T = value_t<Seq>;
+
+    if (begin == end) {
+        return;
+    }
+
+    for (auto cur = next(seq, begin); cur != end; inc(seq, cur)) {
+        cursor_t<Seq> sift = cur;
+        cursor_t<Seq> sift_1 = prev(seq, cur);
+
+        // Compare first so we can avoid 2 moves for an element already
+        // positioned correctly.
+        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
+                         std::invoke(proj, read_at(seq, sift_1)))) {
+            T tmp = move_at(seq, sift);
+
+            do {
+                read_at(seq, sift) = move_at(seq, sift_1);
+                dec(seq, sift);
+            } while (std::invoke(comp, std::invoke(proj, tmp),
+                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+
+            read_at(seq, sift) = std::move(tmp);
+        }
+    }
+}
+
+// Attempts to use insertion sort on [begin, end). Will return false if more
+// than partial_insertion_sort_limit elements were moved, and abort sorting.
+// Otherwise it will successfully sort and return true.
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+{
+    using T = value_t<Seq>;
+
+    if (begin == end) {
+        return true;
+    }
+
+    distance_t<Seq> limit = 0;
+
+    for (auto cur = next(seq, begin); cur != end; inc(seq, cur)) {
+        if (limit > pqdsort_partial_insertion_sort_limit) {
+            return false;
+        }
+
+        cursor_t<Seq> sift = cur;
+        cursor_t<Seq> sift_1 = prev(seq, cur);
+
+        // Compare first so we can avoid 2 moves for an element already
+        // positioned correctly.
+        if (std::invoke(comp, std::invoke(proj, read_at(seq, sift)),
+                         std::invoke(proj, read_at(seq, sift_1)))) {
+            T tmp = move_at(seq, sift);
+
+            do {
+                read_at(seq, sift) = move_at(seq, sift_1);
+                dec(seq, sift);
+            } while (sift != begin &&
+                     std::invoke(comp, std::invoke(proj, tmp),
+                                  std::invoke(proj, read_at(seq, dec(seq, sift_1)))));
+
+            read_at(seq, sift) = std::move(tmp);
+            limit += distance(seq, sift, cur);
+        }
+    }
+
+    return true;
+}
+
+template <sequence Seq, typename Comp, typename Proj>
+constexpr void sort2(Seq& seq, cursor_t<Seq> a, cursor_t<Seq> b, Comp& comp, Proj& proj)
+{
+    if (std::invoke(comp, std::invoke(proj, read_at(seq, b)), std::invoke(proj, read_at(seq, a)))) {
+        swap_at(seq, a, b);
+    }
+}
+
+// Sorts the elements *a, *b and *c using comparison function comp.
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr void sort3(Seq& seq, Cur a, Cur b, Cur c, Comp& comp, Proj& proj)
+{
+    sort2(seq, a, b, comp, proj);
+    sort2(seq, b, c, comp, proj);
+    sort2(seq, a, b, comp, proj);
+}
+
+#if 0
+template <typename I>
+constexpr void swap_offsets(I first, I last, unsigned char* offsets_l,
+                            unsigned char* offsets_r, int num, bool use_swaps)
+{
+    using T = iter_value_t<I>;
+    if (use_swaps) {
+        // This case is needed for the descending distribution, where we need
+        // to have proper swapping for pdqsort to remain O(n).
+        for (int i = 0; i < num; ++i) {
+            nano::iter_swap(first + offsets_l[i], last - offsets_r[i]);
+        }
+    } else if (num > 0) {
+        I l = first + offsets_l[0];
+        I r = last - offsets_r[0];
+        T tmp(nano::iter_move(l));
+        *l = nano::iter_move(r);
+
+        for (int i = 1; i < num; ++i) {
+            l = first + offsets_l[i];
+            *r = nano::iter_move(l);
+            r = last - offsets_r[i];
+            *l = nano::iter_move(r);
+        }
+        *r = std::move(tmp);
+    }
+}
+
+// Partitions [begin, end) around pivot *begin using comparison function comp.
+// Elements equal to the pivot are put in the right-hand partition. Returns the
+// position of the pivot after partitioning and whether the passed sequence
+// already was correctly partitioned. Assumes the pivot is a median of at least
+// 3 elements and that [begin, end) is at least insertion_sort_threshold long.
+// Uses branchless partitioning.
+template <typename I, typename Comp, typename Pred>
+constexpr std::pair<I, bool> partition_right_branchless(I begin, I end,
+                                                        Comp& comp, Pred& pred)
+{
+    using T = iter_value_t<I>;
+
+    // Move pivot into local for speed.
+    T pivot(nano::iter_move(begin));
+    I first = begin;
+    I last = end;
+
+    // Find the first element greater than or equal than the pivot (the median
+    // of 3 guarantees this exists).
+    while (std::invoke(comp, std::invoke(pred, *++first),
+                        std::invoke(pred, pivot)))
+        ;
+
+    // Find the first element strictly smaller than the pivot. We have to guard
+    // this search if there was no element before *first.
+    if (first - 1 == begin) {
+        while (first < last && !std::invoke(comp, std::invoke(pred, *--last),
+                                             std::invoke(pred, pivot)))
+            ;
+    } else {
+        while (!std::invoke(comp, std::invoke(pred, *--last),
+                             std::invoke(pred, pivot)))
+            ;
+    }
+
+    // If the first pair of elements that should be swapped to partition are the
+    // same element, the passed in sequence already was correctly partitioned.
+    bool already_partitioned = first >= last;
+    if (!already_partitioned) {
+        nano::iter_swap(first, last);
+        ++first;
+    }
+
+    // The following branchless partitioning is derived from "BlockQuicksort:
+    // How Branch Mispredictions don't affect Quicksort" by Stefan Edelkamp and
+    // Armin Weiss.
+    alignas(pdqsort_cacheline_size) unsigned char
+        offsets_l_storage[pdqsort_block_size] = {};
+    alignas(pdqsort_cacheline_size) unsigned char
+        offsets_r_storage[pdqsort_block_size] = {};
+    unsigned char* offsets_l = offsets_l_storage;
+    unsigned char* offsets_r = offsets_r_storage;
+    int num_l = 0, num_r = 0, start_l = 0, start_r = 0;
+
+    while (last - first > 2 * pdqsort_block_size) {
+        // Fill up offset blocks with elements that are on the wrong side.
+        if (num_l == 0) {
+            start_l = 0;
+            I it = first;
+            for (unsigned char i = 0; i < pdqsort_block_size;) {
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+                offsets_l[num_l] = i++;
+                num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                       std::invoke(pred, pivot));
+                ++it;
+            }
+        }
+        if (num_r == 0) {
+            start_r = 0;
+            I it = last;
+            for (unsigned char i = 0; i < pdqsort_block_size;) {
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+                offsets_r[num_r] = ++i;
+                num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                      std::invoke(pred, pivot));
+            }
+        }
+
+        // Swap elements and update block sizes and first/last boundaries.
+        int num = (nano::min)(num_l, num_r);
+        swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r, num,
+                     num_l == num_r);
+        num_l -= num;
+        num_r -= num;
+        start_l += num;
+        start_r += num;
+        if (num_l == 0)
+            first += pdqsort_block_size;
+        if (num_r == 0)
+            last -= pdqsort_block_size;
+    }
+
+    iter_difference_t<I> l_size = 0, r_size = 0;
+    iter_difference_t<I> unknown_left =
+        (last - first) - ((num_r || num_l) ? pdqsort_block_size : 0);
+    if (num_r) {
+        // Handle leftover block by assigning the unknown elements to the other
+        // block.
+        l_size = unknown_left;
+        r_size = pdqsort_block_size;
+    } else if (num_l) {
+        l_size = pdqsort_block_size;
+        r_size = unknown_left;
+    } else {
+        // No leftover block, split the unknown elements in two blocks.
+        l_size = unknown_left / 2;
+        r_size = unknown_left - l_size;
+    }
+
+    // Fill offset buffers if needed.
+    if (unknown_left && !num_l) {
+        start_l = 0;
+        I it = first;
+        for (unsigned char i = 0; i < l_size;) {
+            offsets_l[num_l] = i++;
+            num_l += !std::invoke(comp, std::invoke(pred, *it),
+                                   std::invoke(pred, pivot));
+            ++it;
+        }
+    }
+    if (unknown_left && !num_r) {
+        start_r = 0;
+        I it = last;
+        for (unsigned char i = 0; i < r_size;) {
+            offsets_r[num_r] = ++i;
+            num_r += std::invoke(comp, std::invoke(pred, *--it),
+                                  std::invoke(pred, pivot));
+        }
+    }
+
+    int num = (nano::min)(num_l, num_r);
+    swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r, num,
+                 num_l == num_r);
+    num_l -= num;
+    num_r -= num;
+    start_l += num;
+    start_r += num;
+    if (num_l == 0)
+        first += l_size;
+    if (num_r == 0)
+        last -= r_size;
+
+    // We have now fully identified [first, last)'s proper position. Swap the
+    // last elements.
+    if (num_l) {
+        offsets_l += start_l;
+        while (num_l--)
+            nano::iter_swap(first + offsets_l[num_l], --last);
+        first = last;
+    }
+    if (num_r) {
+        offsets_r += start_r;
+        while (num_r--)
+            nano::iter_swap(last - offsets_r[num_r], first), ++first;
+        last = first;
+    }
+
+    // Put the pivot in the right place.
+    I pivot_pos = first - 1;
+    *begin = nano::iter_move(pivot_pos);
+    *pivot_pos = std::move(pivot);
+
+    return std::make_pair(std::move(pivot_pos), already_partitioned);
+}
+#endif
+
+// Partitions [begin, end) around pivot *begin using comparison function comp.
+// Elements equal to the pivot are put in the right-hand partition. Returns the
+// position of the pivot after partitioning and whether the passed sequence
+// already was correctly partitioned. Assumes the pivot is a median of at least
+// 3 elements and that [begin, end) is at least insertion_sort_threshold long.
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr std::pair<cursor_t<Seq>, bool>
+partition_right(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+{
+    using T = value_t<Seq>;
+
+    // Move pivot into local for speed.
+    T pivot(move_at(seq, begin));
+
+    cursor_t<Seq> first = begin;
+    cursor_t<Seq> last = end;
+
+    // Find the first element greater than or equal than the pivot (the median
+    // of 3 guarantees this exists).
+    while (std::invoke(comp, std::invoke(proj, read_at(seq, inc(seq, first))),
+                        std::invoke(proj, pivot))) {
+    }
+
+    // Find the first element strictly smaller than the pivot. We have to guard
+    // this search if there was no element before *first.
+    if (prev(seq, first) == begin) {
+        while (first < last && !std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
+                                             std::invoke(proj, pivot))) {
+        }
+    } else {
+        while (!std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
+                             std::invoke(proj, pivot))) {
+        }
+    }
+
+    // If the first pair of elements that should be swapped to partition are the
+    // same element, the passed in sequence already was correctly partitioned.
+    bool already_partitioned = first >= last;
+
+    // Keep swapping pairs of elements that are on the wrong side of the pivot.
+    // Previously swapped pairs guard the searches, which is why the first
+    // iteration is special-cased above.
+    while (first < last) {
+        swap_at(seq, first, last);
+        while (std::invoke(comp, std::invoke(proj, read_at(seq, inc(seq, first))),
+                            std::invoke(proj, pivot)))
+            ;
+        while (!std::invoke(comp, std::invoke(proj, read_at(seq, dec(seq, last))),
+                             std::invoke(proj, pivot)))
+            ;
+    }
+
+    // Put the pivot in the right place.
+    cursor_t<Seq> pivot_pos = prev(seq, first);
+    read_at(seq, begin) = move_at(seq, pivot_pos);
+    read_at(seq, pivot_pos) = std::move(pivot);
+
+    return std::make_pair(std::move(pivot_pos), already_partitioned);
+}
+
+// Similar function to the one above, except elements equal to the pivot are put
+// to the left of the pivot and it doesn't check or return if the passed
+// sequence already was partitioned. Since this is rarely used (the many equal
+// case), and in that case pdqsort already has O(n) performance, no block
+// quicksort is applied here for simplicity.
+template <sequence Seq, typename Comp, typename Proj, typename Cur = cursor_t<Seq>>
+constexpr cursor_t<Seq> partition_left(Seq& seq, Cur const begin, Cur const end, Comp& comp, Proj& proj)
+{
+    using T = value_t<Seq>;
+
+    T pivot(move_at(seq, begin));
+    cursor_t<Seq> first = begin;
+    cursor_t<Seq> last = end;
+
+    while (std::invoke(comp, std::invoke(proj, pivot),
+                        std::invoke(proj, read_at(seq, dec(seq, last)))))
+        ;
+
+    if (next(seq, last) == end) {
+        while (first < last && !std::invoke(comp, std::invoke(proj, pivot),
+                                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+            ;
+    } else {
+        while (!std::invoke(comp, std::invoke(proj, pivot),
+                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+            ;
+    }
+
+    while (first < last) {
+        swap_at(seq, first, last);
+        while (std::invoke(comp, std::invoke(proj, pivot),
+                            std::invoke(proj, read_at(seq, dec(seq, last)))))
+            ;
+        while (!std::invoke(comp, std::invoke(proj, pivot),
+                             std::invoke(proj, read_at(seq, inc(seq, first)))))
+            ;
+    }
+
+    cursor_t<Seq> pivot_pos = last;
+    read_at(seq, begin) = move_at(seq, pivot_pos);
+    read_at(seq, pivot_pos) = std::move(pivot);
+
+    return pivot_pos;
+}
+
+template <bool Branchless, typename Seq, typename Comp, typename Proj,
+          typename Cur = cursor_t<Seq>>
+constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp, Proj& proj,
+                            int bad_allowed, bool leftmost = true)
+{
+    //using diff_t = iter_difference_t<I>
+    using diff_t = distance_t<Seq>;
+
+    // Use a while loop for tail recursion elimination.
+    while (true) {
+        diff_t size = flux::distance(seq, begin, end);
+
+        // Insertion sort is faster for small arrays.
+        if (size < pdqsort_insertion_sort_threshold) {
+            if (leftmost) {
+                insertion_sort(seq, begin, end, comp, proj);
+            } else {
+                unguarded_insertion_sort(seq, begin, end, comp, proj);
+            }
+            return;
+        }
+
+        // Choose pivot as median of 3 or pseudomedian of 9.
+        diff_t s2 = size / 2;
+        if (size > pdqsort_ninther_threshold) {
+            sort3(seq, begin, next(seq, begin, s2), prev(seq, end), comp, proj);
+            sort3(seq, next(seq, begin), next(seq, begin, s2 - 1), next(seq, end, -2), comp, proj);
+            sort3(seq, next(seq, begin, 2), next(seq, begin, s2 + 1), next(seq, end, -3), comp, proj);
+            sort3(seq, next(seq, begin, s2 - 1), next(seq, begin, s2), next(seq, begin, s2 + 1), comp, proj);
+            swap_at(seq, begin, next(seq, begin, s2));
+        } else {
+            sort3(seq, next(seq, begin, s2), begin, prev(seq, end), comp, proj);
+        }
+
+        // If *(begin - 1) is the end of the right partition of a previous
+        // partition operation there is no element in [begin, end) that is
+        // smaller than *(begin - 1). Then if our pivot compares equal to
+        // *(begin - 1) we change strategy, putting equal elements in the left
+        // partition, greater elements in the right partition. We do not have to
+        // recurse on the left partition, since it's sorted (all equal).
+        if (!leftmost && !std::invoke(comp, std::invoke(proj, read_at(seq, prev(seq, begin))),
+                                       std::invoke(proj, read_at(seq, begin)))) {
+            begin = next(seq, partition_left(seq, begin, end, comp, proj));
+            continue;
+        }
+
+        // Partition and get results.
+        /*
+        std::pair<I, bool> part_result =
+            Branchless ? partition_right_branchless(begin, end, comp, proj)
+                       : partition_right(begin, end, comp, proj);
+        I pivot_pos = part_result.first;
+        bool already_partitioned = part_result.second;*/
+        auto [pivot_pos, already_partitioned] = partition_right(seq, begin, end, comp, proj);
+
+        // Check for a highly unbalanced partition.
+        diff_t l_size = distance(seq, begin, pivot_pos);
+        diff_t r_size = distance(seq, next(seq, pivot_pos), end);
+        bool highly_unbalanced = l_size < size / 8 || r_size < size / 8;
+
+        // If we got a highly unbalanced partition we shuffle elements to break
+        // many patterns.
+        if (highly_unbalanced) {
+            // If we had too many bad partitions, switch to heapsort to
+            // guarantee O(n log n).
+            if (--bad_allowed == 0) {
+                auto view = flux::view(slice(seq, begin, end));
+                std::ranges::make_heap(view, comp, proj);
+                std::ranges::sort_heap(view, comp, proj);
+                return;
+            }
+
+            if (l_size >= pdqsort_insertion_sort_threshold) {
+                swap_at(seq, begin, next(seq, begin, l_size/4));
+                swap_at(seq, prev(seq, pivot_pos), next(seq, pivot_pos, -l_size/4));
+
+                if (l_size > pdqsort_ninther_threshold) {
+                    swap_at(seq, next(seq, begin), next(seq, begin, l_size/4 + 1));
+                    swap_at(seq, next(seq, begin, 2), next(seq, begin, l_size/4 + 2));
+                    swap_at(seq, next(seq, pivot_pos, -2), next(seq, pivot_pos, -(l_size/4 + 1)));
+                    swap_at(seq, next(seq, pivot_pos, -3), next(seq, pivot_pos, -(l_size/4 + 2)));
+                }
+            }
+
+            if (r_size >= pdqsort_insertion_sort_threshold) {
+                swap_at(seq, next(seq, pivot_pos), next(seq, pivot_pos, (1 + r_size/4)));
+                swap_at(seq, prev(seq, end), next(seq, end, -r_size/4));
+
+                if (r_size > pdqsort_ninther_threshold) {
+                    swap_at(seq, next(seq, pivot_pos, 2), next(seq, pivot_pos, 2 + r_size/4));
+                    swap_at(seq, next(seq, pivot_pos, 3), next(seq, pivot_pos, 3 + r_size/4));
+                    swap_at(seq, next(seq, end, -2), next(seq, end, -(1 + r_size/4)));
+                    swap_at(seq, next(seq, end, -3), next(seq, end, -(2 + r_size/4)));
+                }
+            }
+        } else {
+            // If we were decently balanced and we tried to sort an already
+            // partitioned sequence try to use insertion sort.
+            if (already_partitioned &&
+                partial_insertion_sort(seq, begin, pivot_pos, comp, proj) &&
+                partial_insertion_sort(seq, pivot_pos + 1, end, comp, proj))
+                return;
+        }
+
+        // Sort the left partition first using recursion and do tail recursion
+        // elimination for the right-hand partition.
+        detail::pdqsort_loop<Branchless>(seq, begin, pivot_pos, comp, proj,
+                                         bad_allowed, leftmost);
+        begin = next(seq, pivot_pos);
+        leftmost = false;
+    }
+}
+
+template <typename Seq, typename Comp, typename Proj>
+constexpr void pdqsort(Seq& seq, Comp& comp, Proj& proj)
+{
+    if (is_empty(seq)) {
+        return;
+    }
+    /*
+    constexpr bool Branchless =
+         is_default_compare_v<std::remove_const_t<Comp>>&&
+         std::same_as<Proj, identity> &&
+         std::is_arithmetic_v<iter_value_t<I>>::value
+*/
+    constexpr bool Branchless = false;
+    detail::pdqsort_loop<Branchless>(seq,
+                                     first(seq),
+                                     last(seq),
+                                     comp,
+                                     proj,
+                                     detail::log2(size(seq)));
+}
+
+} // namespace detail
+
+} // namespace flux
+
+#endif

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -13,7 +13,8 @@ struct sort_fn {
     template <random_access_sequence Seq, typename Cmp = std::less<>,
               typename Proj = std::identity>
         requires bounded_sequence<Seq> &&
-                 element_swappable_with<Seq, Seq>
+                 element_swappable_with<Seq, Seq> &&
+                 std::predicate<Cmp&, projected_t<Proj, Seq>, projected_t<Proj, Seq>>
     constexpr auto operator()(Seq&& seq, Cmp cmp = {}, Proj proj = {}) const
     {
         detail::pdqsort(seq, cmp, proj);

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -1,0 +1,29 @@
+
+#ifndef FLUX_OP_SORT_HPP_INCLUDED
+#define FLUX_OP_SORT_HPP_INCLUDED
+
+#include <flux/core.hpp>
+#include <flux/op/detail/pdqsort.hpp>
+
+namespace flux {
+
+namespace detail {
+
+struct sort_fn {
+    template <random_access_sequence Seq, typename Cmp = std::less<>,
+              typename Proj = std::identity>
+        requires bounded_sequence<Seq> &&
+                 element_swappable_with<Seq, Seq>
+    constexpr auto operator()(Seq&& seq, Cmp cmp = {}, Proj proj = {}) const
+    {
+        detail::pdqsort(seq, cmp, proj);
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto sort = detail::sort_fn{};
+
+} // namespace flux
+
+#endif // FLUX_OP_SORT_HPP_INCLUDED

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -25,6 +25,17 @@ struct sort_fn {
 
 inline constexpr auto sort = detail::sort_fn{};
 
+template <typename D>
+template <typename Cmp, typename Proj>
+    requires random_access_sequence<D> &&
+             bounded_sequence<D> &&
+             detail::element_swappable_with<D, D> &&
+             std::predicate<Cmp&, projected_t<Proj, D>, projected_t<Proj, D>>
+constexpr void lens_base<D>::sort(Cmp cmp, Proj proj)
+{
+    return flux::sort(derived(), std::move(cmp), std::move(proj));
+}
+
 } // namespace flux
 
 #endif // FLUX_OP_SORT_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(test-libflux
     test_output_to.cpp
     test_reverse.cpp
     test_split.cpp
+    test_sort.cpp
     test_take.cpp
     test_take_while.cpp
     test_to.cpp

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -1,0 +1,71 @@
+
+#include "catch.hpp"
+
+//#define FLUX_ENABLE_BOUNDS_CHECKING
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <memory>
+#include <random>
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <span>
+
+namespace {
+
+template <typename T>
+struct span_seq {
+    T* ptr_;
+    std::size_t sz_;
+
+    static constexpr std::size_t first() { return 0; }
+    constexpr bool is_last(std::size_t i) const { return i == sz_; }
+    constexpr std::size_t& inc(std::size_t& i) const { return ++i; }
+    constexpr T& read_at(std::size_t i) const { return ptr_[i]; }
+    constexpr std::size_t last() const { return sz_; }
+    static constexpr std::size_t& dec(std::size_t& i) { return --i; }
+    static constexpr std::size_t& inc(std::size_t& i, std::ptrdiff_t o) { return i += o; }
+    static constexpr std::ptrdiff_t distance(std::size_t from, std::size_t to)
+    {
+        return static_cast<std::ptrdiff_t>(to) - static_cast<std::ptrdiff_t>(from);
+    }
+    constexpr std::size_t size() { return sz_; }
+    constexpr T* data() const { return ptr_; }
+};
+
+std::mt19937 gen{};
+
+struct Int {
+    int i;
+    Int& operator++() { ++i; return *this; }
+
+    auto operator<=>(Int const&) const = default;
+};
+
+void test_sort(int sz) {
+    auto* ptr = new int[sz];
+    std::iota(ptr, ptr + sz, int{0});
+    std::shuffle(ptr, ptr + sz, gen);
+
+    flux::sort(span_seq(ptr, sz));
+
+    CHECK(std::is_sorted(ptr, ptr + sz));
+    delete[] ptr;
+}
+
+}
+
+TEST_CASE("sort")
+{
+    test_sort(0);
+    test_sort(1);
+    test_sort(10);
+    test_sort(100);
+    test_sort(1'000);
+    test_sort(10'000);
+    test_sort(100'000);
+    test_sort(1'000'000);
+ //   test_sort(10'000'000);
+}

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -40,8 +40,6 @@ std::mt19937 gen{};
 struct Int {
     int i;
     Int& operator++() { ++i; return *this; }
-
-    auto operator<=>(Int const&) const = default;
 };
 
 void test_sort(int sz) {
@@ -50,8 +48,23 @@ void test_sort(int sz) {
     std::shuffle(ptr, ptr + sz, gen);
 
     flux::sort(span_seq(ptr, sz));
+//    std::ranges::sort(std::span(ptr, sz));
 
     CHECK(std::is_sorted(ptr, ptr + sz));
+    delete[] ptr;
+}
+
+void test_sort_projected(int sz)
+{
+    auto* ptr = new Int[sz];
+    std::iota(ptr, ptr + sz, Int{0});
+    std::shuffle(ptr, ptr + sz, gen);
+
+    flux::sort(span_seq(ptr, sz), {}, &Int::i);
+
+    CHECK(std::is_sorted(ptr, ptr + sz, [](Int lhs, Int rhs) {
+        return lhs.i < rhs.i;
+    }));
     delete[] ptr;
 }
 
@@ -68,4 +81,10 @@ TEST_CASE("sort")
     test_sort(100'000);
     test_sort(1'000'000);
  //   test_sort(10'000'000);
+
+    test_sort_projected(0);
+    test_sort_projected(1);
+    test_sort_projected(10);
+    test_sort_projected(100);
+    test_sort_projected(100'000);
 }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <iostream>
 #include <span>
+#include <numeric>
 
 namespace {
 


### PR DESCRIPTION
Flux should have both sort() and stable_sort() algorithms. This PR will hopefully cover the former, at least.

To do:

* [x] Implement `sort()` for random-access, bounded sequences by adapting the pdqsort implementation from NanoRange
* [x] Add a lot of tests
* [x] Add a benchmark or two