### PR TITLE
Add simple_sequence_base

### DIFF
--- a/include/flux/core.hpp
+++ b/include/flux/core.hpp
@@ -11,5 +11,6 @@
 #include <flux/core/lens_base.hpp>
 #include <flux/core/macros.hpp>
 #include <flux/core/sequence_access.hpp>
+#include <flux/core/simple_sequence_base.hpp>
 
 #endif // FLUX_CORE_HPP_INCLUDED

--- a/include/flux/core/simple_sequence_base.hpp
+++ b/include/flux/core/simple_sequence_base.hpp
@@ -1,0 +1,94 @@
+
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_CORE_SIMPLE_SEQUENCE_BASE_HPP_INCLUDED
+#define FLUX_CORE_SIMPLE_SEQUENCE_BASE_HPP_INCLUDED
+
+#include <flux/core/lens_base.hpp>
+
+namespace flux {
+
+template <typename D>
+struct simple_sequence_base : lens_base<D> {};
+
+namespace detail {
+
+template <typename O>
+concept optional_like =
+    std::default_initializable<O> &&
+    std::movable<O> &&
+    requires (O& o) {
+        { static_cast<bool>(o) };
+        { *o } -> flux::detail::can_reference;
+    };
+
+template <typename S>
+concept simple_sequence =
+    std::derived_from<S, simple_sequence_base<S>> &&
+    requires (S& s) {
+        { s.maybe_next() } -> optional_like;
+    };
+
+} // namespace detail
+
+template <detail::simple_sequence S>
+struct sequence_iface<S> {
+private:
+    class cursor_type {
+        friend struct sequence_iface;
+        using optional_t = decltype(FLUX_DECLVAL(S&).maybe_next());
+        optional_t opt_{};
+
+        constexpr cursor_type() = default;
+
+        constexpr explicit cursor_type(optional_t&& opt)
+            : opt_(std::move(opt))
+        {}
+
+    public:
+        cursor_type(cursor_type&&) = default;
+        cursor_type& operator=(cursor_type&&) = default;
+    };
+
+public:
+    static constexpr bool is_infinite = detail::is_infinite_seq<S>;
+
+    static constexpr auto first(S& self) -> cursor_type
+    {
+        return cursor_type(self.maybe_next());
+    }
+
+    static constexpr auto is_last(S&, cursor_type const& cur) -> bool
+    {
+        return !static_cast<bool>(cur.opt_);
+    }
+
+    static constexpr auto inc(S& self, cursor_type& cur) -> cursor_type&
+    {
+        cur.opt_ = self.maybe_next();
+        return cur;
+    }
+
+    static constexpr auto read_at(S&, cursor_type const& cur) -> decltype(auto)
+    {
+        return *cur.opt_;
+    }
+
+    static constexpr auto for_each_while(S& self, auto&& pred) -> cursor_type
+    {
+        while (auto o = self.maybe_next()) {
+            if (!std::invoke(pred, *o)) {
+                return cursor_type(std::move(o));
+            }
+        }
+        return cursor_type{};
+    }
+};
+
+} // namespace flux
+
+#endif // FLUX_CORE_SIMPLE_SEQUENCE_BASE_HPP_INCLUDED
+
+

--- a/include/flux/op/for_each.hpp
+++ b/include/flux/op/for_each.hpp
@@ -15,7 +15,8 @@ namespace detail {
 struct for_each_fn {
 
     template <sequence Seq, typename Func, typename Proj = std::identity>
-        requires std::invocable<Func&, projected_t<Proj, Seq>>
+        requires (std::invocable<Func&, projected_t<Proj, Seq>> &&
+                  !infinite_sequence<Seq>)
     constexpr auto operator()(Seq&& seq, Func func, Proj proj = {}) const -> Func
     {
         (void) flux::for_each_while(FLUX_FWD(seq), [&](auto&& elem) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ target_compile_features(catch-main PUBLIC cxx_std_20)
 add_executable(test-libflux
 
     test_concepts.cpp
+    test_simple_sequence.cpp
 
     test_all_any_none.cpp
     test_bounds_checked.cpp
@@ -37,7 +38,6 @@ add_executable(test-libflux
     test_istream.cpp
     test_istreambuf.cpp
     test_single.cpp
-    #hack_hack_hack.cpp
 )
 target_link_libraries(test-libflux flux catch-main)
 

--- a/test/test_simple_sequence.cpp
+++ b/test/test_simple_sequence.cpp
@@ -86,6 +86,17 @@ constexpr bool test_simple_sequence()
         STATIC_CHECK(sum == 45);
     }
 
+    // Check that we can restart iteration
+    {
+        std::array<int, 5> arr{1, 2, 3, 4, 5};
+        auto iter = array_iterator(arr);
+
+        auto cur = iter.find(3);
+        auto slice = flux::slice(iter, std::move(cur), flux::last);
+
+        STATIC_CHECK(check_equal(slice, {3, 4, 5}));
+    }
+
     return true;
 }
 static_assert(test_simple_sequence());

--- a/test/test_simple_sequence.cpp
+++ b/test/test_simple_sequence.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+template <typename T, std::size_t N>
+struct array_iterator : flux::simple_sequence_base<array_iterator<T, N>> {
+private:
+    std::array<T, N>* array_;
+    std::size_t idx_ = 0;
+
+public:
+    constexpr explicit array_iterator(std::array<T, N>& arr)
+        : array_(std::addressof(arr))
+    {}
+
+    constexpr auto maybe_next() -> T*
+    {
+        if (idx_ < N) {
+            return &array_->at(idx_++);
+        } else {
+            return nullptr;
+        }
+    }
+};
+
+struct ints : flux::simple_sequence_base<ints> {
+    int i = 0;
+
+    static constexpr bool is_infinite = true;
+
+    constexpr auto maybe_next() -> std::optional<int>
+    {
+        return {i++};
+    }
+};
+
+constexpr bool test_simple_sequence()
+{
+    {
+        std::array<int, 5> arr{1, 2, 3, 4, 5};
+        auto iter = array_iterator(arr);
+
+        using I = decltype(iter);
+        static_assert(flux::detail::simple_sequence<I>);
+        static_assert(flux::sequence<I>);
+        static_assert(flux::lens<I>);
+        static_assert(not flux::multipass_sequence<I>);
+        static_assert(not flux::sized_sequence<I>);
+        static_assert(not flux::infinite_sequence<I>);
+
+        static_assert(std::same_as<flux::element_t<I>, int&>);
+        static_assert(std::same_as<flux::value_t<I>, int>);
+        static_assert(std::same_as<flux::rvalue_element_t<I>, int&&>);
+
+        iter.fill(10);
+
+        STATIC_CHECK(check_equal(array_iterator(arr), {10, 10, 10, 10, 10}));
+    }
+
+    {
+        static_assert(flux::detail::simple_sequence<ints>);
+        static_assert(flux::sequence<ints>);
+        static_assert(flux::infinite_sequence<ints>);
+        static_assert(not flux::multipass_sequence<ints>);
+        static_assert(not flux::sized_sequence<ints>);
+        static_assert(std::same_as<flux::element_t<ints>, int const&>);
+        static_assert(std::same_as<flux::value_t<ints>, int>);
+        static_assert(std::same_as<flux::rvalue_element_t<ints>, int const&&>);
+
+        // FIXME: ints{}.take(10).sum()
+        int sum = 0;
+        ints{}.take(10).for_each([&sum](int const& i) {
+            sum += i;
+        });
+
+        STATIC_CHECK(sum == 45);
+    }
+
+    return true;
+}
+static_assert(test_simple_sequence());
+
+}
+
+TEST_CASE("simple_sequence")
+{
+    bool result = test_simple_sequence();
+    REQUIRE(result);
+}


### PR DESCRIPTION
This is a sequence wrapper which allow you to define a sequence as a Rust/Swift/Flow style iterator, by writing a class which inherits from flux::simple_sequence_base and provides a member function named maybe_next() which returns something "optional-like" (for example, a std::optional, a boost::optional, or a raw pointer).

For example:

```cpp
struct some_ints : flux::simple_sequence_base<some_ints>
{
    int i = 0;

    std::optional<int> maybe_next()
    {
        if (i < 10) {
            return {i++};
        } else {
            return std::nullopt;
        }
    }
};
```

simple_sequence_base in turn inherits from lens_base and so provides all the usual member functions. It's for this reason that the require method is called maybe_next() rather than the more usual next() -- the latter would hide the declaration of flow_base::next, and so would require a using declaration to bring it back into scope.