### PR TITLE
Fix GH Actions CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@master
 
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: Build
       run: |
         brew install gcc@11 lcov ninja

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         include:
           - cxx: g++-11
             install: brew install gcc@11

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: Create Build Environment
       run: |
         ${{matrix.install}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,9 @@ jobs:
         os: [ubuntu-latest]
         include:
           - cxx: g++-11
-            install: brew install gcc@11
+            install: |
+              brew install gcc@11 ninja
+              brew link --force binutils
 
     steps:
     - uses: actions/checkout@v2
@@ -30,16 +32,13 @@ jobs:
 
     - name: Configure
       working-directory: ${{runner.workspace}}/build
-      env:
-        CXX: ${{matrix.cxx}}
-        CXXFLAGS: ${{matrix.cxx_flags}}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}}  \
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_COMPILER=${{matrix.cxx}} \
               $GITHUB_WORKSPACE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config ${{matrix.build_type}} -- -j2
+      run: cmake --build .
 
     - name: Test
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
Github Actions' Ubuntu runners have recently removed Homebrew from their $PATH, breaking thousands of projects, including this one. Hopefully this fixes it.

See

https://github.com/actions/runner-images/issues/6283