### PR TITLE
Don't implicitly reference sequences in adaptors

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -286,8 +286,9 @@ constexpr bool is_ilist<T, std::initializer_list<E>> = true;
 template <typename Seq>
 concept adaptable_sequence =
     sequence<Seq> &&
-    (std::is_lvalue_reference_v<Seq> ||
-        (std::movable<std::remove_reference_t<Seq>> && !detail::is_ilist<Seq>));
+    !std::is_reference_v<Seq> &&
+    std::movable<Seq> &&
+    !detail::is_ilist<Seq>;
 
 template <typename D>
 struct lens_base;

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -297,13 +297,25 @@ constexpr bool is_ilist = false;
 template <typename T, typename E>
 constexpr bool is_ilist<T, std::initializer_list<E>> = true;
 
+template <typename Seq>
+concept rvalue_sequence =
+    !std::is_reference_v<Seq> &&
+    std::movable<Seq> &&
+    sequence<Seq>;
+
+template <typename Seq>
+concept trivially_copyable_sequence =
+    std::copyable<Seq> &&
+    std::is_trivially_copyable_v<Seq> &&
+    sequence<Seq>;
+
 }
 
 template <typename Seq>
 concept adaptable_sequence =
-    sequence<Seq> &&
-    !std::is_reference_v<Seq> &&
-    std::movable<Seq> &&
+    (detail::rvalue_sequence<Seq>
+         || (std::is_lvalue_reference_v<Seq> &&
+             detail::trivially_copyable_sequence<std::decay_t<Seq>>)) &&
     !detail::is_ilist<Seq>;
 
 template <typename D>

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -17,10 +17,26 @@
 namespace flux {
 
 /*
- * Useful helper concepts
+ * Useful helpers
  */
 template <typename From, typename To>
 concept decays_to = std::same_as<std::remove_cvref_t<From>, To>;
+
+namespace detail {
+
+struct copy_fn {
+    template <typename T>
+    constexpr auto operator()(T&& arg) const
+        noexcept(std::is_nothrow_convertible_v<T, std::decay_t<T>>)
+        -> std::decay_t<T>
+    {
+        return FLUX_FWD(arg);
+    }
+};
+
+}
+
+inline constexpr auto copy = detail::copy_fn{};
 
 /*
  * Cursor concepts

--- a/include/flux/op/bounds_checked.hpp
+++ b/include/flux/op/bounds_checked.hpp
@@ -23,8 +23,8 @@ private:
     friend struct sequence_iface<bounds_checked_adaptor>;
 
 public:
-    constexpr explicit bounds_checked_adaptor(Base&& base)
-        : base_(std::move(base))
+    constexpr explicit bounds_checked_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
     {}
 
     constexpr auto base() -> Base& { return base_; }
@@ -36,7 +36,7 @@ struct bounds_checked_fn {
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const
     {
-        return bounds_checked_adaptor(FLUX_FWD(seq));
+        return bounds_checked_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
     }
 };
 
@@ -78,13 +78,12 @@ struct sequence_iface<detail::bounds_checked_adaptor<Base>>
 
     static constexpr auto slice(auto& self, auto first, auto last)
     {
-        return detail::bounds_checked_adaptor(
-            flux::from(flux::slice(self.base_, std::move(first), std::move(last))));
+        return detail::bounds_checked_fn{}(flux::slice(self.base_, std::move(first), std::move(last)));
     }
 
     static constexpr auto slice(auto& self, auto first)
     {
-        return detail::bounds_checked_adaptor(flux::from(flux::slice(self.base_, std::move(first), flux::last)));
+        return detail::bounds_checked_fn{}(flux::slice(self.base_, std::move(first), flux::last));
     }
 };
 

--- a/include/flux/op/bounds_checked.hpp
+++ b/include/flux/op/bounds_checked.hpp
@@ -14,7 +14,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base>
+template <sequence Base>
 struct bounds_checked_adaptor : lens_base<bounds_checked_adaptor<Base>>
 {
 private:
@@ -36,7 +36,7 @@ struct bounds_checked_fn {
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const
     {
-        return bounds_checked_adaptor(flux::from(FLUX_FWD(seq)));
+        return bounds_checked_adaptor(FLUX_FWD(seq));
     }
 };
 

--- a/include/flux/op/cache_last.hpp
+++ b/include/flux/op/cache_last.hpp
@@ -28,8 +28,8 @@ private:
     constexpr auto base() -> Base& { return base_; }
 
 public:
-    constexpr explicit cache_last_adaptor(Base&& base)
-        : base_(std::move(base))
+    constexpr explicit cache_last_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
     {}
 };
 
@@ -37,12 +37,13 @@ struct cache_last_fn {
     template <adaptable_sequence Seq>
         requires bounded_sequence<Seq> ||
             (multipass_sequence<Seq> && not infinite_sequence<Seq>)
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const
     {
         if constexpr (bounded_sequence<Seq>) {
             return FLUX_FWD(seq);
         } else {
-            return cache_last_adaptor(FLUX_FWD(seq));
+            return cache_last_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
         }
     }
 };

--- a/include/flux/op/cache_last.hpp
+++ b/include/flux/op/cache_last.hpp
@@ -15,7 +15,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base>
+template <sequence Base>
 struct cache_last_adaptor : lens_base<cache_last_adaptor<Base>>
 {
 private:
@@ -40,9 +40,9 @@ struct cache_last_fn {
     constexpr auto operator()(Seq&& seq) const
     {
         if constexpr (bounded_sequence<Seq>) {
-            return flux::from(FLUX_FWD(seq));
+            return FLUX_FWD(seq);
         } else {
-            return cache_last_adaptor(flux::from(FLUX_FWD(seq)));
+            return cache_last_adaptor(FLUX_FWD(seq));
         }
     }
 };

--- a/include/flux/op/cartesian_product.hpp
+++ b/include/flux/op/cartesian_product.hpp
@@ -28,18 +28,19 @@ private:
     friend struct sequence_iface<cartesian_product_adaptor>;
 
 public:
-    constexpr explicit cartesian_product_adaptor(Bases&&... bases)
-        : bases_(std::move(bases)...)
+    constexpr explicit cartesian_product_adaptor(decays_to<Bases> auto&&... bases)
+        : bases_(FLUX_FWD(bases)...)
     {}
 };
 
 struct cartesian_product_fn {
     template <adaptable_sequence Seq0, adaptable_sequence... Seqs>
         requires (multipass_sequence<Seqs> && ...)
+    [[nodiscard]]
     constexpr auto operator()(Seq0&& seq0, Seqs&&... seqs) const
     {
-        return cartesian_product_adaptor(FLUX_FWD(seq0),
-                                         FLUX_FWD(seqs)...);
+        return cartesian_product_adaptor<std::decay_t<Seq0>, std::decay_t<Seqs>...>(
+                    FLUX_FWD(seq0), FLUX_FWD(seqs)...);
     }
 };
 

--- a/include/flux/op/cartesian_product.hpp
+++ b/include/flux/op/cartesian_product.hpp
@@ -18,7 +18,7 @@ namespace detail {
 template <typename... Bases>
 struct cartesian_product_iface_base;
 
-template <lens... Bases>
+template <sequence... Bases>
 struct cartesian_product_adaptor
     : lens_base<cartesian_product_adaptor<Bases...>> {
 private:
@@ -38,8 +38,8 @@ struct cartesian_product_fn {
         requires (multipass_sequence<Seqs> && ...)
     constexpr auto operator()(Seq0&& seq0, Seqs&&... seqs) const
     {
-        return cartesian_product_adaptor(flux::from(FLUX_FWD(seq0)),
-                                         flux::from(FLUX_FWD(seqs))...);
+        return cartesian_product_adaptor(FLUX_FWD(seq0),
+                                         FLUX_FWD(seqs)...);
     }
 };
 

--- a/include/flux/op/cartesian_product_with.hpp
+++ b/include/flux/op/cartesian_product_with.hpp
@@ -23,9 +23,9 @@ private:
     friend struct sequence_iface<cartesian_product_with_adaptor>;
 
 public:
-    constexpr explicit cartesian_product_with_adaptor(Func func, Bases&&... bases)
-        : bases_(std::move(bases)...),
-          func_(std::move(func))
+    constexpr explicit cartesian_product_with_adaptor(decays_to<Func> auto&& func, decays_to<Bases> auto&&... bases)
+        : bases_(FLUX_FWD(bases)...),
+          func_(FLUX_FWD(func))
     {}
 };
 
@@ -34,11 +34,11 @@ struct cartesian_product_with_fn
     template <typename Func, adaptable_sequence Seq0, adaptable_sequence... Seqs>
         requires (multipass_sequence<Seqs> && ...) &&
         std::regular_invocable<Func&, element_t<Seq0>, element_t<Seqs>...>
+    [[nodiscard]]
     constexpr auto operator()(Func func, Seq0&& seq0, Seqs&&... seqs) const
     {
-        return cartesian_product_with_adaptor(std::move(func),
-                                              FLUX_FWD(seq0),
-                                              FLUX_FWD(seqs)...);
+        return cartesian_product_with_adaptor<Func, std::decay_t<Seq0>, std::decay_t<Seqs>...>(
+                    std::move(func), FLUX_FWD(seq0), FLUX_FWD(seqs)...);
     }
 };
 

--- a/include/flux/op/cartesian_product_with.hpp
+++ b/include/flux/op/cartesian_product_with.hpp
@@ -12,7 +12,7 @@ namespace flux {
 
 namespace detail {
 
-template <typename Func, lens... Bases>
+template <typename Func, sequence... Bases>
 struct cartesian_product_with_adaptor
     : lens_base<cartesian_product_with_adaptor<Func, Bases...>> {
 private:
@@ -37,8 +37,8 @@ struct cartesian_product_with_fn
     constexpr auto operator()(Func func, Seq0&& seq0, Seqs&&... seqs) const
     {
         return cartesian_product_with_adaptor(std::move(func),
-                                              flux::from(FLUX_FWD(seq0)),
-                                              flux::from(FLUX_FWD(seqs))...);
+                                              FLUX_FWD(seq0),
+                                              FLUX_FWD(seqs)...);
     }
 };
 

--- a/include/flux/op/chain.hpp
+++ b/include/flux/op/chain.hpp
@@ -24,8 +24,8 @@ private:
     friend struct sequence_iface<chain_adaptor>;
 
 public:
-    explicit constexpr chain_adaptor(Bases&&... bases)
-        : bases_(std::move(bases)...)
+    explicit constexpr chain_adaptor(decays_to<Bases> auto&&... bases)
+        : bases_(FLUX_FWD(bases)...)
     {}
 };
 
@@ -44,12 +44,13 @@ struct chain_fn {
     template <adaptable_sequence... Seqs>
         requires (sizeof...(Seqs) >= 1) &&
                  chainable<Seqs...>
+    [[nodiscard]]
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 1) {
             return std::forward<Seqs...>(seqs...);
         } else {
-            return chain_adaptor(FLUX_FWD(seqs)...);
+            return chain_adaptor<std::decay_t<Seqs>...>(FLUX_FWD(seqs)...);
         }
     }
 };

--- a/include/flux/op/chain.hpp
+++ b/include/flux/op/chain.hpp
@@ -16,7 +16,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens... Bases>
+template <sequence... Bases>
 struct chain_adaptor : lens_base<chain_adaptor<Bases...>> {
 private:
     std::tuple<Bases...> bases_;
@@ -47,9 +47,9 @@ struct chain_fn {
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 1) {
-            return flux::from(FLUX_FWD(seqs)...);
+            return std::move(seqs...);
         } else {
-            return chain_adaptor(flux::from(FLUX_FWD(seqs))...);
+            return chain_adaptor(FLUX_FWD(seqs)...);
         }
     }
 };

--- a/include/flux/op/chain.hpp
+++ b/include/flux/op/chain.hpp
@@ -47,7 +47,7 @@ struct chain_fn {
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 1) {
-            return std::move(seqs...);
+            return std::forward<Seqs...>(seqs...);
         } else {
             return chain_adaptor(FLUX_FWD(seqs)...);
         }

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -25,8 +25,8 @@ private:
     friend struct sequence_iface<drop_adaptor>;
 
 public:
-    constexpr drop_adaptor(Base&& base, distance_t<Base> count)
-        : base_(std::move(base)),
+    constexpr drop_adaptor(decays_to<Base> auto&& base, distance_t<Base> count)
+        : base_(FLUX_FWD(base)),
           count_(count)
     {}
 
@@ -36,9 +36,10 @@ public:
 
 struct drop_fn {
     template <adaptable_sequence Seq>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, distance_t<Seq> count) const
     {
-        return drop_adaptor(FLUX_FWD(seq), count);
+        return drop_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count);
     }
 
 };

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -15,7 +15,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base>
+template <sequence Base>
 struct drop_adaptor : lens_base<drop_adaptor<Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -38,7 +38,7 @@ struct drop_fn {
     template <adaptable_sequence Seq>
     constexpr auto operator()(Seq&& seq, distance_t<Seq> count) const
     {
-        return drop_adaptor(flux::from(FLUX_FWD(seq)), count);
+        return drop_adaptor(FLUX_FWD(seq), count);
     }
 
 };

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -28,18 +28,19 @@ private:
     constexpr auto base() & -> Base& { return base_; }
 
 public:
-    constexpr drop_while_adaptor(Base&& base, Pred&& pred)
-        : base_(std::move(base)),
-          pred_(std::move(pred))
+    constexpr drop_while_adaptor(decays_to<Base> auto&& base, decays_to<Pred> auto&& pred)
+        : base_(FLUX_FWD(base)),
+          pred_(FLUX_FWD(pred))
     {}
 };
 
 struct drop_while_fn {
     template <adaptable_sequence Seq, typename Pred>
         requires std::predicate<Pred&, element_t<Seq>>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return drop_while_adaptor(FLUX_FWD(seq), std::move(pred));
+        return drop_while_adaptor<std::decay_t<Seq>, Pred>(FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -15,7 +15,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base, typename Pred>
+template <sequence Base, typename Pred>
 struct drop_while_adaptor : lens_base<drop_while_adaptor<Base, Pred>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -39,7 +39,7 @@ struct drop_while_fn {
         requires std::predicate<Pred&, element_t<Seq>>
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return drop_while_adaptor(flux::from(FLUX_FWD(seq)), std::move(pred));
+        return drop_while_adaptor(FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -16,7 +16,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base, typename Pred>
+template <sequence Base, typename Pred>
     requires std::predicate<Pred&, element_t<Base>&>
 class filter_adaptor : public lens_base<filter_adaptor<Base, Pred>>
 {
@@ -44,7 +44,7 @@ struct filter_fn {
         requires std::predicate<Pred&, element_t<Seq>&>
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return filter_adaptor(flux::from(FLUX_FWD(seq)), std::move(pred));
+        return filter_adaptor(FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -25,9 +25,9 @@ class filter_adaptor : public lens_base<filter_adaptor<Base, Pred>>
     std::optional<cursor_t<Base>> cached_first_{};
 
 public:
-    constexpr filter_adaptor(Base&& base, Pred&& pred)
-        : base_(std::move(base)),
-          pred_(std::move(pred))
+    constexpr filter_adaptor(decays_to<Base> auto&& base, decays_to<Pred> auto&& pred)
+        : base_(FLUX_FWD(base)),
+          pred_(FLUX_FWD(pred))
     {}
 
     [[nodiscard]]
@@ -42,9 +42,10 @@ public:
 struct filter_fn {
     template <adaptable_sequence Seq, typename Pred>
         requires std::predicate<Pred&, element_t<Seq>&>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return filter_adaptor(FLUX_FWD(seq), std::move(pred));
+        return filter_adaptor<std::decay_t<Seq>, Pred>(FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/from.hpp
+++ b/include/flux/op/from.hpp
@@ -14,18 +14,13 @@ namespace flux {
 namespace detail {
 
 struct from_fn {
-    template <adaptable_sequence Seq>
+    template <sequence Seq>
+        requires (std::is_lvalue_reference_v<Seq> || adaptable_sequence<Seq>)
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const -> lens auto
     {
-        if constexpr (lens<std::remove_cvref_t<Seq>>) {
-            if constexpr (std::is_lvalue_reference_v<Seq>) {
-                return flux::ref(seq);
-            } else {
-                return FLUX_FWD(seq);
-            }
-        } else if constexpr (std::is_lvalue_reference_v<Seq>) {
-            return detail::ref_adaptor<std::remove_reference_t<Seq>>(seq);
+        if constexpr (std::is_lvalue_reference_v<Seq>) {
+            return flux::ref(seq);
         } else {
             return detail::owning_adaptor<Seq>(FLUX_FWD(seq));
         }

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -25,9 +25,9 @@ private:
     friend struct sequence_iface<map_adaptor>;
 
 public:
-    constexpr map_adaptor(Base&& base, Func&& func)
-        : base_(std::move(base)),
-          func_(std::move(func))
+    constexpr map_adaptor(decays_to<Base> auto&& base, decays_to<Func> auto&& func)
+        : base_(FLUX_FWD(base)),
+          func_(FLUX_FWD(func))
     {}
 
     constexpr auto base() & -> Base& { return base_; }
@@ -40,9 +40,10 @@ struct map_fn {
 
     template <adaptable_sequence Seq, typename Func>
         requires std::regular_invocable<Func&, element_t<Seq>>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Func func) const
     {
-        return map_adaptor(FLUX_FWD(seq), std::move(func));
+        return map_adaptor<std::decay_t<Seq>, Func>(FLUX_FWD(seq), std::move(func));
     }
 };
 

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -13,7 +13,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base, typename Func>
+template <sequence Base, typename Func>
     requires std::is_object_v<Func> &&
              std::regular_invocable<Func&, element_t<Base>>
 struct map_adaptor : lens_base<map_adaptor<Base, Func>>
@@ -42,7 +42,7 @@ struct map_fn {
         requires std::regular_invocable<Func&, element_t<Seq>>
     constexpr auto operator()(Seq&& seq, Func func) const
     {
-        return map_adaptor(flux::from(FLUX_FWD(seq)), std::move(func));
+        return map_adaptor(FLUX_FWD(seq), std::move(func));
     }
 };
 

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -31,9 +31,8 @@ struct rev_cur {
 template <typename B>
 rev_cur(B&&) -> rev_cur<std::remove_cvref_t<B>>;
 
-template <lens Base>
-    requires bidirectional_sequence<Base> &&
-             bounded_sequence<Base>
+template <bidirectional_sequence Base>
+    requires bounded_sequence<Base>
 struct reverse_adaptor : lens_base<reverse_adaptor<Base>>
 {
 private:
@@ -67,7 +66,7 @@ struct reverse_fn {
         if constexpr (is_reverse_adaptor<std::decay_t<Seq>>) {
             return FLUX_FWD(seq).base();
         } else {
-            return reverse_adaptor(flux::from(FLUX_FWD(seq)));
+            return reverse_adaptor(FLUX_FWD(seq));
         }
     }
 };

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -41,8 +41,8 @@ private:
     friend struct sequence_iface<reverse_adaptor>;
 
 public:
-    constexpr explicit reverse_adaptor(Base&& base)
-        : base_(std::move(base))
+    constexpr explicit reverse_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
     {}
 
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
@@ -61,12 +61,12 @@ struct reverse_fn {
                  bounded_sequence<Seq>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const
-        -> lens auto
+        -> sequence auto
     {
         if constexpr (is_reverse_adaptor<std::decay_t<Seq>>) {
             return FLUX_FWD(seq).base();
         } else {
-            return reverse_adaptor(FLUX_FWD(seq));
+            return reverse_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
         }
     }
 };

--- a/include/flux/op/split.hpp
+++ b/include/flux/op/split.hpp
@@ -17,7 +17,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base, lens Pattern>
+template <multipass_sequence Base, multipass_sequence Pattern>
 struct split_adaptor : lens_base<split_adaptor<Base, Pattern>> {
 private:
     Base base_;
@@ -39,7 +39,7 @@ struct split_fn {
                  std::equality_comparable_with<element_t<Seq>, element_t<Pattern>>
     constexpr auto operator()(Seq&& seq, Pattern&& pattern) const
     {
-        return split_adaptor(flux::from(FLUX_FWD(seq)), flux::from(FLUX_FWD(pattern)));
+        return split_adaptor(FLUX_FWD(seq), FLUX_FWD(pattern));
     }
 
     template <adaptable_sequence Seq>

--- a/include/flux/op/take.hpp
+++ b/include/flux/op/take.hpp
@@ -37,8 +37,8 @@ private:
     friend struct sequence_iface<take_adaptor>;
 
 public:
-    constexpr take_adaptor(Base&& base, distance_t<Base> count)
-        : base_(std::move(base)),
+    constexpr take_adaptor(decays_to<Base> auto&& base, distance_t<Base> count)
+        : base_(FLUX_FWD(base)),
           count_(count)
     {}
 
@@ -49,6 +49,7 @@ public:
 struct take_fn {
 
     template <adaptable_sequence Seq>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, distance_t<Seq> count) const
     {
         if constexpr (random_access_sequence<Seq> && std::is_lvalue_reference_v<Seq>) {
@@ -56,7 +57,7 @@ struct take_fn {
             auto last = flux::next(seq, first, count);
             return flux::from(flux::slice(seq, std::move(first), std::move(last)));
         } else {
-            return take_adaptor(FLUX_FWD(seq), count);
+            return take_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count);
         }
     }
 };

--- a/include/flux/op/take.hpp
+++ b/include/flux/op/take.hpp
@@ -14,7 +14,7 @@ namespace flux {
 
 namespace detail {
 
-template <typename Base>
+template <sequence Base>
 struct take_adaptor : lens_base<take_adaptor<Base>>
 {
 private:
@@ -56,7 +56,7 @@ struct take_fn {
             auto last = flux::next(seq, first, count);
             return flux::from(flux::slice(seq, std::move(first), std::move(last)));
         } else {
-            return take_adaptor(flux::from(FLUX_FWD(seq)), count);
+            return take_adaptor(FLUX_FWD(seq), count);
         }
     }
 };

--- a/include/flux/op/take_while.hpp
+++ b/include/flux/op/take_while.hpp
@@ -25,9 +25,9 @@ private:
     friend struct passthrough_iface_base<Base>;
 
 public:
-    constexpr take_while_adaptor(Base&& base, Pred&& pred)
-        : base_(std::move(base)),
-          pred_(std::move(pred))
+    constexpr take_while_adaptor(decays_to<Base> auto&& base, decays_to<Pred> auto&& pred)
+        : base_(FLUX_FWD(base)),
+          pred_(FLUX_FWD(pred))
     {}
 
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
@@ -37,9 +37,11 @@ public:
 struct take_while_fn {
     template <adaptable_sequence Seq, typename Pred>
         requires std::predicate<Pred&, element_t<Seq>&>
+    [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return take_while_adaptor(FLUX_FWD(seq), std::move(pred));
+        return take_while_adaptor<std::decay_t<Seq>, Pred>(
+                    FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/take_while.hpp
+++ b/include/flux/op/take_while.hpp
@@ -13,7 +13,7 @@ namespace flux {
 
 namespace detail {
 
-template <lens Base, typename Pred>
+template <sequence Base, typename Pred>
 struct take_while_adaptor : lens_base<take_while_adaptor<Base, Pred>> {
 private:
     Base base_;
@@ -39,7 +39,7 @@ struct take_while_fn {
         requires std::predicate<Pred&, element_t<Seq>&>
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
-        return take_while_adaptor(flux::from(FLUX_FWD(seq)), std::move(pred));
+        return take_while_adaptor(FLUX_FWD(seq), std::move(pred));
     }
 };
 

--- a/include/flux/op/to.hpp
+++ b/include/flux/op/to.hpp
@@ -157,7 +157,7 @@ constexpr auto to(Seq&& seq, Args&&... args) -> Container
         }
     } else {
         static_assert(sequence<element_t<Seq>>);
-        return flux::to<Container>(flux::map(FLUX_FWD(seq), [](auto&& elem) {
+        return flux::to<Container>(flux::map(flux::from(FLUX_FWD(seq)), [](auto&& elem) {
             return flux::to<detail::container_value_t<Container>>(FLUX_FWD(elem));
         }), FLUX_FWD(args)...);
     }

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -45,7 +45,7 @@ struct zip_fn {
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 0) {
-            return empty<std::tuple<>>{};
+            return empty<std::tuple<>>;
         } else {
             return zip_adaptor<std::decay_t<Seqs>...>(FLUX_FWD(seqs)...);
         }

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -34,19 +34,20 @@ private:
     friend struct sequence_iface<zip_adaptor>;
 
 public:
-    constexpr explicit zip_adaptor(Bases&&... bases)
-        : bases_(std::move(bases)...)
+    constexpr explicit zip_adaptor(decays_to<Bases> auto&&... bases)
+        : bases_(FLUX_FWD(bases)...)
     {}
 };
 
 struct zip_fn {
     template <adaptable_sequence... Seqs>
+    [[nodiscard]]
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 0) {
             return empty<std::tuple<>>{};
         } else {
-            return zip_adaptor(FLUX_FWD(seqs)...);
+            return zip_adaptor<std::decay_t<Seqs>...>(FLUX_FWD(seqs)...);
         }
     }
 };

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -26,7 +26,7 @@ struct pair_or_tuple<T, U> {
 template <typename... Ts>
 using pair_or_tuple_t = typename pair_or_tuple<Ts...>::type;
 
-template <lens... Bases>
+template <sequence... Bases>
 struct zip_adaptor : lens_base<zip_adaptor<Bases...>> {
 private:
     pair_or_tuple_t<Bases...> bases_;
@@ -44,9 +44,9 @@ struct zip_fn {
     constexpr auto operator()(Seqs&&... seqs) const
     {
         if constexpr (sizeof...(Seqs) == 0) {
-            return empty<std::tuple<>>;
+            return empty<std::tuple<>>{};
         } else {
-            return zip_adaptor(flux::from(FLUX_FWD(seqs))...);
+            return zip_adaptor(FLUX_FWD(seqs)...);
         }
     }
 };

--- a/include/flux/ranges/view.hpp
+++ b/include/flux/ranges/view.hpp
@@ -31,7 +31,7 @@ consteval auto get_iterator_tag()
     }
 }
 
-template <lens Base>
+template <sequence Base>
 struct view_adaptor : std::ranges::view_interface<view_adaptor<Base>>
 {
 private:
@@ -249,7 +249,11 @@ struct view_fn {
         if constexpr (std::ranges::viewable_range<Seq>) {
             return std::views::all(FLUX_FWD(seq));
         } else {
-            return view_adaptor(flux::from(FLUX_FWD(seq)));
+            if constexpr (std::is_lvalue_reference_v<Seq>) {
+                return view_adaptor(flux::ref(FLUX_FWD(seq)));
+            } else {
+                return view_adaptor(FLUX_FWD(seq));
+            }
         }
     }
 };

--- a/include/flux/source/empty.hpp
+++ b/include/flux/source/empty.hpp
@@ -45,8 +45,7 @@ public:
 
 template <typename T>
     requires std::is_object_v<T>
-using empty = detail::empty_sequence<T>;
-//inline constexpr auto empty = detail::empty_sequence<T>{};
+inline constexpr auto empty = detail::empty_sequence<T>{};
 
 } // namespace flux
 

--- a/include/flux/source/empty.hpp
+++ b/include/flux/source/empty.hpp
@@ -45,7 +45,8 @@ public:
 
 template <typename T>
     requires std::is_object_v<T>
-inline constexpr auto empty = detail::empty_sequence<T>{};
+using empty = detail::empty_sequence<T>;
+//inline constexpr auto empty = detail::empty_sequence<T>{};
 
 } // namespace flux
 

--- a/test/test_bitset.cpp
+++ b/test/test_bitset.cpp
@@ -39,7 +39,7 @@ constexpr bool test_bitset()
         static_assert(flux::size(b) == 32);
 
         uint32_t x = 0;
-        FLUX_FOR(bool bit, flux::reverse(std::as_const(b))) {
+        FLUX_FOR(bool bit, flux::reverse(flux::ref(std::as_const(b)))) {
             x <<= 1;
             x |= uint32_t(bit);
         }

--- a/test/test_bounds_checked.cpp
+++ b/test/test_bounds_checked.cpp
@@ -22,7 +22,7 @@ constexpr bool test_bounds_checked()
     {
         int arr[] = {0, 1, 2, 3, 4};
 
-        auto seq = flux::bounds_checked(arr).map([](int i) { return i * 2; });
+        auto seq = flux::bounds_checked(flux::ref(arr)).map([](int i) { return i * 2; });
 
         using S = decltype(seq);
 
@@ -57,7 +57,7 @@ TEST_CASE("bounds_checked")
     {
         int arr[] = {0, 1, 2, 3, 4};
 
-        auto seq = flux::bounds_checked(arr);
+        auto seq = flux::bounds_checked(flux::ref(arr));
 
         SECTION("Can read from in-bounds indices")
         {

--- a/test/test_cache_last.cpp
+++ b/test/test_cache_last.cpp
@@ -17,11 +17,11 @@ constexpr bool test_cache_last()
     // cache_last turns an unbounded sequence into a bounded one
     {
         std::array arr{1, 2, 3, 4, 5};
-        auto seq = flux::take_while(arr, [](int){ return true; });
+        auto seq = flux::take_while(flux::ref(arr), [](int){ return true; });
 
         static_assert(not flux::bounded_sequence<decltype(seq)>);
 
-        auto cached = flux::cache_last(seq);
+        auto cached = flux::cache_last(std::move(seq));
 
         using C = decltype(cached);
 
@@ -45,7 +45,7 @@ constexpr bool test_cache_last()
         std::array arr{1, 2, 3, 4, 5};
 
         auto seq = flux::from(arr);
-        auto cached = flux::cache_last(seq);
+        auto cached = flux::cache_last(flux::ref(seq));
 
         STATIC_CHECK(&seq.base() == &cached.base());
         STATIC_CHECK(&cached.base() == &arr);

--- a/test/test_cartesian_product.cpp
+++ b/test/test_cartesian_product.cpp
@@ -20,7 +20,7 @@ constexpr bool test_cartesian_product()
         std::array arr1{100, 200};
         std::array arr2{1.0f, 2.0f};
 
-        auto cart = flux::cartesian_product(arr1, arr2);
+        auto cart = flux::cartesian_product(flux::ref(arr1), flux::ref(arr2));
 
         using C = decltype(cart);
 

--- a/test/test_cartesian_product_with.cpp
+++ b/test/test_cartesian_product_with.cpp
@@ -105,7 +105,7 @@ constexpr bool test_cartesian_product_with()
     // Product with a zero-sized sequence works and produces an empty sequence
     {
         auto arr = std::array{1, 2, 3, 4, 5};
-        auto emp = flux::empty<int>{};
+        auto emp = flux::empty<int>;
 
         auto cart = flux::cartesian_product_with(sum, flux::ref(arr), std::move(emp));
 

--- a/test/test_cartesian_product_with.cpp
+++ b/test/test_cartesian_product_with.cpp
@@ -22,7 +22,7 @@ constexpr bool test_cartesian_product_with()
         std::array arr1{100, 200};
         std::array arr2{1, 2, 3, 4, 5};
 
-        auto cart = flux::cartesian_product_with(sum, arr1, arr2);
+        auto cart = flux::cartesian_product_with(sum, flux::ref(arr1), flux::ref(arr2));
         using C = decltype(cart);
 
         static_assert(flux::sequence<C>);
@@ -38,7 +38,7 @@ constexpr bool test_cartesian_product_with()
                                          201, 202, 203, 204, 205
                                        }));
 
-        STATIC_CHECK(check_equal(flux::reverse(cart),
+        STATIC_CHECK(check_equal(flux::reverse(flux::ref(cart)),
                                  { 205, 204, 203, 202, 201,
                                    105, 104, 103, 102, 101
                                  }));
@@ -59,7 +59,7 @@ constexpr bool test_cartesian_product_with()
         std::array arr2{10, 20, 30};
         std::array arr3{1, 2, 3, 4};
 
-        auto cart = flux::cartesian_product_with(sum, arr1, arr2, arr3);
+        auto cart = flux::cartesian_product_with(sum, flux::ref(arr1), flux::ref(arr2), flux::ref(arr3));
         using C = decltype(cart);
 
         static_assert(flux::sequence<C>);
@@ -105,9 +105,9 @@ constexpr bool test_cartesian_product_with()
     // Product with a zero-sized sequence works and produces an empty sequence
     {
         auto arr = std::array{1, 2, 3, 4, 5};
-        auto emp = flux::empty<int>;
+        auto emp = flux::empty<int>{};
 
-        auto cart = flux::cartesian_product_with(sum, arr, emp);
+        auto cart = flux::cartesian_product_with(sum, flux::ref(arr), std::move(emp));
 
         static_assert(flux::bidirectional_sequence<decltype(cart)>);
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -24,7 +24,7 @@ constexpr bool test_chain()
         int arr2[] = {3, 4, 5};
         int arr3[] = {6, 7, 8};
 
-        auto seq = flux::chain(arr1, arr2, arr3);
+        auto seq = flux::chain(flux::ref(arr1), flux::ref(arr2), flux::ref(arr3));
 
         using S = decltype(seq);
 
@@ -101,7 +101,7 @@ constexpr bool test_chain()
         int arr2[] = {3, 4, 5};
         auto yes = [](int) { return true; };
 
-        auto seq = flux::chain(flux::filter(arr1, yes), flux::filter(arr2, yes));
+        auto seq = flux::chain(flux::filter(flux::ref(arr1), yes), flux::filter(flux::from(arr2), yes));
 
         using S = decltype(seq);
 
@@ -116,7 +116,7 @@ constexpr bool test_chain()
         int arr1[] = {0, 1, 2};
         int arr2[] = {3, 4, 5};
 
-        auto seq = flux::chain(arr1, arr2).reverse();
+        auto seq = flux::chain(flux::ref(arr1), flux::ref(arr2)).reverse();
 
         STATIC_CHECK(check_equal(seq, {5, 4, 3, 2, 1, 0}));
     }
@@ -126,16 +126,16 @@ constexpr bool test_chain()
         int arr1[] = {0, 1, 2};
         std::array arr2 = {3, 4, 5};
 
-        auto seq = flux::chain(arr1,
-                               flux::empty<int const>,
-                               arr2,
-                               flux::empty<int const>,
+        auto seq = flux::chain(flux::ref(arr1),
+                               flux::empty<int const>{},
+                               flux::ref(arr2),
+                               flux::empty<int const>{},
                                std::array{6, 7, 8});
 
         STATIC_CHECK(flux::size(seq) == 9);
         STATIC_CHECK(check_equal(seq, {0, 1, 2, 3, 4, 5, 6, 7, 8}));
 
-        auto seq2 = flux::chain(flux::empty<int>, flux::empty<int>, flux::empty<int>);
+        auto seq2 = flux::chain(flux::empty<int>{}, flux::empty<int>{}, flux::empty<int>{});
         STATIC_CHECK(seq2.size() == 0);
         STATIC_CHECK(seq2.is_last(seq2.first()));
     }
@@ -145,10 +145,10 @@ constexpr bool test_chain()
         int arr1[] = {9, 8, 7};
         std::array arr2 = {6, 5, 4};
 
-        auto seq = flux::chain(arr1,
-                               flux::empty<int>,
-                               arr2,
-                               flux::empty<int>,
+        auto seq = flux::chain(flux::ref(arr1),
+                               flux::empty<int>{},
+                               flux::ref(arr2),
+                               flux::empty<int>{},
                                std::array{3, 2, 1});
 
         std::ranges::sort(seq.view());

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -127,15 +127,15 @@ constexpr bool test_chain()
         std::array arr2 = {3, 4, 5};
 
         auto seq = flux::chain(flux::ref(arr1),
-                               flux::empty<int const>{},
+                               flux::empty<int const>,
                                flux::ref(arr2),
-                               flux::empty<int const>{},
+                               flux::empty<int const>,
                                std::array{6, 7, 8});
 
         STATIC_CHECK(flux::size(seq) == 9);
         STATIC_CHECK(check_equal(seq, {0, 1, 2, 3, 4, 5, 6, 7, 8}));
 
-        auto seq2 = flux::chain(flux::empty<int>{}, flux::empty<int>{}, flux::empty<int>{});
+        auto seq2 = flux::chain(flux::empty<int>, flux::empty<int>, flux::empty<int>);
         STATIC_CHECK(seq2.size() == 0);
         STATIC_CHECK(seq2.is_last(seq2.first()));
     }
@@ -146,9 +146,9 @@ constexpr bool test_chain()
         std::array arr2 = {6, 5, 4};
 
         auto seq = flux::chain(flux::ref(arr1),
-                               flux::empty<int>{},
+                               flux::empty<int>,
                                flux::ref(arr2),
-                               flux::empty<int>{},
+                               flux::empty<int>,
                                std::array{3, 2, 1});
 
         std::ranges::sort(seq.view());

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -205,22 +205,14 @@ namespace {
 
     static_assert(flux::sequence<movable_seq>);
     static_assert(flux::adaptable_sequence<movable_seq>);
-    static_assert(flux::adaptable_sequence<movable_seq&>);
-    static_assert(flux::adaptable_sequence<movable_seq const&>);
-    static_assert(flux::adaptable_sequence<movable_seq&&>);
     static_assert(not flux::adaptable_sequence<movable_seq const&&>);
 
     static_assert(flux::sequence<move_only_seq>);
     static_assert(flux::adaptable_sequence<move_only_seq>);
-    static_assert(flux::adaptable_sequence<move_only_seq&>);
-    static_assert(flux::adaptable_sequence<move_only_seq const&>);
-    static_assert(flux::adaptable_sequence<move_only_seq&&>);
     static_assert(not flux::adaptable_sequence<move_only_seq const&&>);
 
     static_assert(flux::sequence<unmovable_seq>);
     static_assert(not flux::adaptable_sequence<unmovable_seq>);
-    static_assert(flux::adaptable_sequence<unmovable_seq&>);
-    static_assert(flux::adaptable_sequence<unmovable_seq const&>);
     static_assert(not flux::adaptable_sequence<unmovable_seq&&>);
     static_assert(not flux::adaptable_sequence<unmovable_seq const&&>);
 
@@ -228,8 +220,6 @@ namespace {
 
     static_assert(flux::sequence<ilist_t>);
     static_assert(not flux::adaptable_sequence<ilist_t>);
-    static_assert(flux::adaptable_sequence<ilist_t&>);
-    static_assert(flux::adaptable_sequence<ilist_t const&>);
     static_assert(not flux::adaptable_sequence<ilist_t&&>);
     static_assert(not flux::adaptable_sequence<ilist_t const&&>);
 }

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -28,7 +28,7 @@ constexpr bool test_count()
         int arr[] = {1, 2, 3, 4, 5};
         STATIC_CHECK(flux::count(arr) == 5);
 
-        auto seq = flux::take_while(arr, [](int) { return true; });
+        auto seq = flux::take_while(flux::ref(arr), [](int) { return true; });
         static_assert(not flux::sized_sequence<decltype(seq)>);
 
         STATIC_CHECK(flux::count(seq) == 5);
@@ -38,7 +38,7 @@ constexpr bool test_count()
         int arr[] = {1, 2, 3, 4, 5};
         STATIC_CHECK(flux::from(arr).count() == 5);
 
-        auto seq = flux::take_while(arr, [](int) { return true; });
+        auto seq = flux::take_while(flux::ref(arr), [](int) { return true; });
         static_assert(not flux::sized_sequence<decltype(seq)>);
 
         STATIC_CHECK(seq.count() == 5);

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -21,7 +21,7 @@ constexpr bool test_drop() {
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        auto dropped = flux::drop(arr, 5);
+        auto dropped = flux::drop(flux::ref(arr), 5);
 
         using D = decltype(dropped);
 

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -18,7 +18,7 @@ constexpr bool test_drop_while()
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        auto seq = flux::drop_while(arr, [](int i) { return i < 5; });
+        auto seq = flux::drop_while(flux::ref(arr), [](int i) { return i < 5; });
 
         using S = decltype(seq);
 
@@ -50,7 +50,7 @@ constexpr bool test_drop_while()
     {
         int arr[] = {2, 2, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        auto seq = flux::drop_while(arr, [](int i) { return i % 2 == 0; });
+        auto seq = flux::drop_while(flux::ref(arr), [](int i) { return i % 2 == 0; });
 
         STATIC_CHECK(check_equal(seq, {3, 4, 5, 6, 7, 8, 9}));
     }
@@ -70,7 +70,7 @@ constexpr bool test_drop_while()
 
         std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        STATIC_CHECK(check_equal(flux::drop_while(arr, no), arr));
+        STATIC_CHECK(check_equal(flux::drop_while(flux::ref(arr), no), arr));
     }
 
     return true;

--- a/test/test_empty.cpp
+++ b/test/test_empty.cpp
@@ -9,8 +9,8 @@
 
 namespace {
 
-auto e = flux::empty<double>;
-auto f = flux::empty<double>;
+auto e = flux::empty<double>{};
+auto f = flux::empty<double>{};
 
 static_assert(flux::contiguous_sequence<decltype(e)>);
 static_assert(flux::sized_sequence<decltype(e)>);

--- a/test/test_empty.cpp
+++ b/test/test_empty.cpp
@@ -9,8 +9,8 @@
 
 namespace {
 
-auto e = flux::empty<double>{};
-auto f = flux::empty<double>{};
+auto e = flux::empty<double>;
+auto f = flux::empty<double>;
 
 static_assert(flux::contiguous_sequence<decltype(e)>);
 static_assert(flux::sized_sequence<decltype(e)>);

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -83,11 +83,11 @@ constexpr bool test_equal()
     // Two empty sequences compare equal if their element types are comparable
     {
         std::array<int, 0> seq1{};
-        auto seq2 = flux::take_while(seq1, [](int) { return true; }); // not sized
+        auto seq2 = flux::take_while(flux::ref(seq1), [](int) { return true; }); // not sized
 
         STATIC_CHECK(flux::equal(seq1, seq2));
 
-        static_assert(flux::equal(flux::empty<int>, flux::empty<float>));
+        static_assert(flux::equal(flux::empty<int>{}, flux::empty<float>{}));
     }
 
     return true;

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -87,7 +87,7 @@ constexpr bool test_equal()
 
         STATIC_CHECK(flux::equal(seq1, seq2));
 
-        static_assert(flux::equal(flux::empty<int>{}, flux::empty<float>{}));
+        static_assert(flux::equal(flux::empty<int>, flux::empty<float>));
     }
 
     return true;

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -48,7 +48,7 @@ constexpr bool test_fill()
 
     // empty sequences can be "filled"
     {
-        auto e = flux::empty<int>{};
+        auto e = flux::empty<int>;
         flux::fill(e, 99);
     }
 

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -32,7 +32,7 @@ constexpr bool test_fill()
     {
         std::array<int, 5> arr{};
 
-        flux::take(arr, 3).fill(1);
+        flux::take(flux::ref(arr), 3).fill(1);
 
         STATIC_CHECK(check_equal(arr, {1, 1, 1, 0, 0}));
     }
@@ -48,7 +48,7 @@ constexpr bool test_fill()
 
     // empty sequences can be "filled"
     {
-        auto e = flux::empty<int>;
+        auto e = flux::empty<int>{};
         flux::fill(e, 99);
     }
 

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -28,8 +28,6 @@ struct Pair {
 
 using filter_fn = decltype(flux::filter);
 
-// Okay
-static_assert(std::invocable<filter_fn, int(&)[10], decltype(is_even)>);
 // int is not a sequence
 static_assert(not std::invocable<filter_fn, int, decltype(is_even)>);
 // int is not a predicate
@@ -45,7 +43,7 @@ constexpr bool test_filter()
     // Basic filtering
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = flux::filter(arr, is_even);
+        auto filtered = flux::filter(flux::ref(arr), is_even);
         using F = decltype(filtered);
         static_assert(flux::sequence<F>);
         static_assert(flux::bidirectional_sequence<F>);
@@ -78,7 +76,7 @@ constexpr bool test_filter()
     // A predicate that always returns true returns what it was given
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = flux::filter(arr, [](auto&&) { return true; });
+        auto filtered = flux::filter(flux::ref(arr), [](auto&&) { return true; });
 
         if (!check_equal(arr, filtered)) {
             return false;
@@ -88,7 +86,7 @@ constexpr bool test_filter()
     // A predicate that always returns false returns an empty sequence
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = flux::filter(arr, [](auto&&) { return false; });
+        auto filtered = flux::filter(flux::ref(arr), [](auto&&) { return false; });
 
         if (!filtered.is_empty()) {
             return false;
@@ -104,7 +102,7 @@ constexpr bool test_filter()
             {4, false}
         };
 
-        auto f = flux::filter(pairs, &Pair::ok);
+        auto f = flux::filter(flux::ref(pairs), &Pair::ok);
 
         if (!check_equal(f, {Pair{1, true}, Pair{3, true}})) {
             return false;
@@ -120,7 +118,7 @@ constexpr bool test_filter()
             {4, false}
         };
 
-        auto f = flux::filter(pairs, &Pair::is_okay);
+        auto f = flux::filter(std::move(pairs), &Pair::is_okay);
 
         if (!check_equal(f, {Pair{1, true}, Pair{3, true}})) {
             return false;
@@ -130,7 +128,7 @@ constexpr bool test_filter()
     // Reversed sequences can be filtered
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = flux::reverse(arr).filter(is_even);
+        auto filtered = flux::ref(arr).reverse().filter(is_even);
 
         if (!check_equal(filtered, {8, 6, 4, 2, 0})) {
             return false;
@@ -140,7 +138,7 @@ constexpr bool test_filter()
     // ... and filtered sequences can be reversed
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = flux::filter(arr, is_even).reverse();
+        auto filtered = flux::filter(flux::ref(arr), is_even).reverse();
 
         if (!check_equal(filtered, {8, 6, 4, 2, 0})) {
             return false;

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -19,7 +19,7 @@ constexpr bool test_map()
     {
         int arr[] = {0, 1, 2, 3, 4};
 
-        auto mapped = flux::map(arr, [](int& i) { return i * 2; });
+        auto mapped = flux::map(flux::ref(arr), [](int& i) { return i * 2; });
 
         using M = decltype(mapped);
 
@@ -101,7 +101,7 @@ constexpr bool test_map()
 
         int arr[] = {0, 1, 2, 3, 4};
 
-        auto view = flux::map(arr, times_two).view();
+        auto view = flux::map(flux::ref(arr), times_two).view();
 
         using V = decltype(view);
 
@@ -111,7 +111,7 @@ constexpr bool test_map()
         static_assert(std::ranges::common_range<V>);
         static_assert(std::ranges::sized_range<V>);
 
-        STATIC_CHECK(std::ranges::equal(view | std::views::transform(times_two),
+        STATIC_CHECK(std::ranges::equal(std::views::transform(view, times_two),
                                         std::array{0, 4, 8, 12, 16}));
     }
 

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -19,7 +19,7 @@ constexpr bool test_reverse()
     {
         int arr[] = {0, 1, 2, 3, 4};
 
-        auto reversed = flux::reverse(arr);
+        auto reversed = flux::reverse(flux::ref(arr));
 
         using R = decltype(reversed);
 
@@ -77,7 +77,7 @@ constexpr bool test_reverse()
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(std::same_as<S, decltype(flux::reverse(arr))>);
+        static_assert(std::same_as<S, decltype(flux::reverse(flux::ref(arr)))>);
 
         STATIC_CHECK(check_equal(seq, {4, 3, 2, 1, 0}));
     }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -73,7 +73,7 @@ constexpr bool test_sort_contexpr()
             "delta"sv
         };
 
-        flux::zip(std::array{3, 2, 4, 1}, arr)
+        flux::zip(std::array{3, 2, 4, 1}, flux::ref(arr))
             .sort(std::ranges::greater{},
                   [](auto const& elem) { return std::get<0>(elem); });
 

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -29,7 +29,7 @@ constexpr bool test_split()
     {
         auto sv = "the quick brown fox"sv;
 
-        auto split = flux::split(sv, ' ');
+        auto split = flux::split(flux::ref(sv), ' ');
 
         static_assert(flux::detail::has_overloaded_slice<decltype(flux::ref(sv))>);
 
@@ -69,7 +69,7 @@ constexpr bool test_split()
     {
         int nums[] = {0, 1, 2, 3, 99};
 
-        auto split = flux::split(nums, std::array{1, 2, 3});
+        auto split = flux::split(flux::ref(nums), std::array{1, 2, 3});
 
         static_assert(
             flux::contiguous_sequence<flux::element_t<decltype(split)>>);

--- a/test/test_take.cpp
+++ b/test/test_take.cpp
@@ -17,8 +17,7 @@ constexpr bool test_take()
 {
     {
         int arr[] = {0, 1, 2, 3, 4};
-//        auto taken = flux::take(arr, 3);
-        auto taken = flux::detail::take_adaptor(flux::from(arr), 3);
+        auto taken = flux::take(std::ref(arr), 3);
 
         using T = decltype(taken);
         static_assert(flux::contiguous_sequence<T>);

--- a/test/test_to.cpp
+++ b/test/test_to.cpp
@@ -199,7 +199,7 @@ TEST_CASE("to")
         SECTION("recursive to() calls")
         {
             std::string const str = "The quick brown fox";
-            auto vec = flux::split(str, ' ').to<std::vector<std::string>>();
+            auto vec = flux::split(flux::ref(str), ' ').to<std::vector<std::string>>();
 
             CHECK(check_equal(vec, {"The", "quick", "brown", "fox"}));
         }
@@ -209,7 +209,7 @@ TEST_CASE("to")
             using Alloc = my_allocator<std::string>;
 
             std::string const str = "The quick brown fox";
-            auto vec = flux::split(str, ' ').to<std::vector<std::string, Alloc>>(Alloc{});
+            auto vec = flux::split(flux::ref(str), ' ').to<std::vector<std::string, Alloc>>(Alloc{});
 
             using V = decltype(vec);
             static_assert(std::same_as<typename V::allocator_type, Alloc>);

--- a/test/test_zip.cpp
+++ b/test/test_zip.cpp
@@ -21,7 +21,7 @@ constexpr bool test_zip()
         int arr1[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         double arr2[] = {0, 100, 200, 300, 400};
 
-        auto zipped = flux::zip(arr1, arr2);
+        auto zipped = flux::zip(flux::ref(arr1), flux::ref(arr2));
 
         using Z = decltype(zipped);
 
@@ -112,7 +112,7 @@ constexpr bool test_zip()
         move_only arr1[] = {1, 2, 3, 4, 5};
         move_only arr2[] = {100, 200, 300, 400, 500};
 
-        auto zipped = flux::zip(arr1, arr2);
+        auto zipped = flux::zip(flux::ref(arr1), flux::ref(arr2));
 
         using Z = decltype(zipped);
         static_assert(flux::random_access_sequence<Z>);
@@ -132,7 +132,7 @@ constexpr bool test_zip()
         std::array arr2 = {0, 100, 200, 300, 400};
         std::array arr3 = {'o', 'l', 'l', 'e', 'h', '\0'};
 
-        flux::inplace_reverse(flux::zip(arr1, arr2, arr3));
+        flux::inplace_reverse(flux::zip(flux::ref(arr1), flux::ref(arr2), flux::ref(arr3)));
 
         STATIC_CHECK(arr1 == std::array{4, 3, 2, 1, 0, 5, 6, 7, 8, 9});
         STATIC_CHECK(arr2 == std::array{400, 300, 200, 100, 0});
@@ -144,7 +144,7 @@ constexpr bool test_zip()
         std::array arr2 = {0.0, 100.0, 200.0, 300.0, 400.0};
         std::array arr3 = {'o', 'l', 'l', 'e', 'h', '\0'};
 
-        auto view = flux::zip(arr1, arr2, arr3).view();
+        auto view = flux::zip(flux::ref(arr1), flux::ref(arr2), flux::ref(arr3)).view();
 
         using V = decltype(view);
 


### PR DESCRIPTION
Warning: huge, massive, invasive changes ahead.

Up until this point, we have basically followed the design of Ranges, albeit with "views" renamed to "lenses". Adaptors act on "lenses", and the factory functions automatically turn any sequence into a lens: for lvalues, by (effectively) by using flux::ref, and for rvalues by wrapping them in flux::owning_adaptor.

Unfortunately, this has a pretty major downside: adaptors very often end up implicitly holding references to sequences, with all the lifetime issues that entails. For example, saying:

    auto vec = std::vector{1, 2, 3, 4, 5};
    auto filter = flux::filter(vec, [](int i) { return true; });

Then `filter` contains a reference to `vec`, and its lifetime must not exceed that of the vector it is referencing: but this isn't made clear anywhere in the code. With these changes, you now need to explicitly say:

     auto filter = flux::filter(flux::ref(vec), [](int i) { return true; });

(or flux::ref(vec).filter(...)) which makes it clearer what is going on. This should also avoid various cases where we were uninitentionally wrapping a ref_view in an owning_view in a ref_view etc, which the optimiser can cut through okay but is less than ideal in debug builds (these were probably mistakes on my part, but still...)

With this commit, we modify the adaptable_sequence concept so that it is only satisified by *rvalue* sequences. This means that you must pass an rvalue to an adaptor function: this can be achieved either by making an explicit copy, an explicit move, or explicitly constructing a ref_adaptor via flux::ref (for lvalues). We're putting the user in charge, or at least that's the idea.