### PR TITLE
Allow sequence impls to be nested classes

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -353,106 +353,19 @@ concept predicate_for =
 /*
  * Default sequence_iface implementation
  */
+namespace detail {
+
 template <typename T>
-struct sequence_iface {
+concept has_nested_sequence_impl =
+    requires { typename T::flux_sequence_iface; } &&
+    std::is_class_v<typename T::flux_sequence_iface>;
 
-    static_assert(!detail::derived_from_lens_base<T>,
-        "Types deriving from lens_base cannot define the sequence interface "
-        "in-class. Provide a separate specialisation of sequence_iface instead.");
+}
 
-    static constexpr bool using_primary_template = true;
+template <typename T>
+    requires detail::has_nested_sequence_impl<T>
+struct sequence_iface<T> : T::flux_sequence_iface {};
 
-    static constexpr bool disable_multipass = detail::disable_multipass<T>;
-    static constexpr bool is_infinite = detail::is_infinite_seq<T>;
-
-    /* sequence interface */
-    static constexpr auto first(decays_to<T> auto& self)
-        -> decltype(self.first())
-    {
-        return self.first();
-    }
-
-    template <decays_to<T> Self>
-    static constexpr auto is_last(Self& self, cursor_t<Self> const& cur)
-        -> decltype(self.is_last(cur))
-    {
-        return self.is_last(cur);
-    }
-
-    template <decays_to<T> Self>
-    static constexpr auto read_at(Self& self, cursor_t<Self> const& cur)
-        -> decltype(self.read_at(cur))
-    {
-        return self.read_at(cur);
-    }
-
-    template <decays_to<T> Self>
-    static constexpr auto inc(Self& self, cursor_t<Self>& cur)
-        -> decltype(self.inc(cur))
-    {
-        return self.inc(cur);
-    }
-
-    /* bidirectional sequence interface */
-    template <decays_to<T> Self>
-    static constexpr auto dec(Self& self, cursor_t<Self>& cur)
-        -> decltype(self.dec(cur))
-    {
-        return self.dec(cur);
-    }
-
-    /* random-access sequence interface */
-    template <decays_to<T> Self>
-    static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_t<Self> offset)
-        -> decltype(self.inc(cur, offset))
-    {
-        return self.inc(cur, offset);
-    }
-
-    template <decays_to<T> Self>
-    static constexpr auto distance(Self& self, cursor_t<Self> const& from,
-                                   cursor_t<Self> const& to)
-        -> decltype(self.distance(from, to))
-    {
-        return self.distance(from, to);
-    }
-
-    /* contiguous sequence interface */
-    static constexpr auto data(decays_to<T> auto& self)
-        -> decltype(self.data())
-    {
-        return self.data();
-    }
-
-    /* sized sequence interface */
-    static constexpr auto size(decays_to<T> auto& self)
-        -> decltype(self.size())
-    {
-        return self.size();
-    }
-
-    /* bounded sequence interface */
-    static constexpr auto last(decays_to<T> auto& self)
-        -> decltype(self.last())
-    {
-        return self.last();
-    }
-
-    /* other customisation points */
-    template <decays_to<T> Self>
-    static constexpr auto move_at(Self& self, cursor_t<Self> const& cur)
-        -> decltype(self.move_at(cur))
-    {
-        return self.move_at(cur);
-    }
-
-    template <decays_to<T> Self, typename Pred>
-    static constexpr auto for_each_while(Self& self, Pred&& pred)
-        -> decltype(self.for_each_while(FLUX_FWD(pred)))
-    {
-        return self.for_each_while(FLUX_FWD(pred));
-    }
-};
 
 } // namespace flux
 

--- a/include/flux/op/bounds_checked.hpp
+++ b/include/flux/op/bounds_checked.hpp
@@ -46,6 +46,8 @@ template <typename Base>
 struct sequence_iface<detail::bounds_checked_adaptor<Base>>
     : detail::passthrough_iface_base<Base>
 {
+    using value_type = value_t<Base>;
+
     static constexpr auto read_at(auto& self, auto const& cur)
         -> decltype(flux::checked_read_at(self.base_, cur))
     {

--- a/include/flux/op/bounds_checked.hpp
+++ b/include/flux/op/bounds_checked.hpp
@@ -31,6 +31,9 @@ public:
     struct flux_sequence_iface : detail::passthrough_iface_base<Base> {
         using value_type = value_t<Base>;
 
+        static constexpr bool disable_multipass = !multipass_sequence<Base>;
+        static constexpr bool is_infinite = infinite_sequence<Base>;
+
         static constexpr auto read_at(auto& self, auto const& cur)
             -> decltype(flux::checked_read_at(self.base_, cur))
         {

--- a/include/flux/op/cache_last.hpp
+++ b/include/flux/op/cache_last.hpp
@@ -36,6 +36,8 @@ public:
         using value_type = value_t<Base>;
         using self_t = cache_last_adaptor;
 
+        static constexpr bool disable_multipass = !multipass_sequence<Base>;
+
         static constexpr auto is_last(self_t& self, cursor_t<Base> const& cur)
         {
             if (flux::is_last(self.base_, cur)) {

--- a/include/flux/op/cache_last.hpp
+++ b/include/flux/op/cache_last.hpp
@@ -54,6 +54,7 @@ template <typename Base>
 struct sequence_iface<detail::cache_last_adaptor<Base>>
     : detail::passthrough_iface_base<Base> {
 
+    using value_type = value_t<Base>;
     using self_t = detail::cache_last_adaptor<Base>;
 
     static constexpr auto is_last(self_t& self, cursor_t<self_t> const& cur)

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -36,6 +36,8 @@ public:
         using value_type = value_t<Base>;
         using self_t = drop_while_adaptor;
 
+        static constexpr bool disable_multipass = !multipass_sequence<Base>;
+
         static constexpr auto first(self_t& self)
         {
             if constexpr (std::copy_constructible<cursor_t<Base>>) {

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -50,6 +50,7 @@ template <typename Base, typename Pred>
 struct sequence_iface<detail::drop_while_adaptor<Base, Pred>>
     : detail::passthrough_iface_base<Base>
 {
+    using value_type = value_t<Base>;
     using self_t = detail::drop_while_adaptor<Base, Pred>;
 
     static constexpr auto first(self_t& self)

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -39,6 +39,9 @@ public:
     {
         using value_type = std::remove_cvref_t<std::invoke_result_t<Func&, element_t<Base>>>;
 
+        static constexpr bool disable_multipass = !multipass_sequence<Base>;
+        static constexpr bool is_infinite = infinite_sequence<Base>;
+
         template <typename Self>
         static constexpr auto read_at(Self& self, cursor_t<Self> const& cur)
             -> decltype(std::invoke(self.func_, flux::read_at(self.base_, cur)))

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -89,9 +89,6 @@ struct passthrough_iface_base {
 
     using distance_type = distance_t<Base>;
 
-    static constexpr bool disable_multipass = !multipass_sequence<Base>;
-    static constexpr bool is_infinite = infinite_sequence<Base>;
-
     static constexpr auto first(auto& self)
         -> decltype(flux::first(self.base()))
     {

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -81,13 +81,12 @@ public:
     friend struct sequence_iface<owning_adaptor>;
 };
 
-template <sequence Base>
+template <typename Base>
 struct passthrough_iface_base {
 
     template <typename Self>
     using cursor_t = decltype(flux::first(FLUX_DECLVAL(Self&).base()));
 
-    using value_type = value_t<Base>;
     using distance_type = distance_t<Base>;
 
     static constexpr bool disable_multipass = !multipass_sequence<Base>;
@@ -195,11 +194,15 @@ struct passthrough_iface_base {
 
 template <typename Base>
 struct sequence_iface<detail::ref_adaptor<Base>>
-    : detail::passthrough_iface_base<Base> {};
+    : detail::passthrough_iface_base<Base> {
+    using value_type = value_t<Base>;
+};
 
 template <typename Base>
 struct sequence_iface<detail::owning_adaptor<Base>>
-    : detail::passthrough_iface_base<Base> {};
+    : detail::passthrough_iface_base<Base> {
+    using value_type = value_t<Base>;
+};
 
 inline constexpr auto ref = detail::ref_fn{};
 

--- a/include/flux/op/slice.hpp
+++ b/include/flux/op/slice.hpp
@@ -97,6 +97,7 @@ template <typename Base, bool Bounded>
 struct sequence_iface<subsequence<Base, Bounded>>
     : detail::passthrough_iface_base<Base>
 {
+    using value_type = value_t<Base>;
     using self_t = subsequence<Base, Bounded>;
 
     static constexpr auto first(self_t& self) -> cursor_t<Base>

--- a/include/flux/op/take_while.hpp
+++ b/include/flux/op/take_while.hpp
@@ -53,6 +53,8 @@ struct sequence_iface<detail::take_while_adaptor<Base, Pred>>
 {
     using self_t = detail::take_while_adaptor<Base, Pred>;
 
+    using value_type = value_t<Base>;
+
     static constexpr bool is_infinite = false;
 
     template <typename Self>

--- a/include/flux/source/empty.hpp
+++ b/include/flux/source/empty.hpp
@@ -16,29 +16,46 @@ namespace detail {
 
 template <typename T>
     requires std::is_object_v<T>
-struct empty_sequence {
-private:
-    struct cursor_type {
-        friend constexpr bool operator==(cursor_type, cursor_type) = default;
-        friend constexpr auto operator<=>(cursor_type, cursor_type) = default;
+struct empty_sequence : lens_base<empty_sequence<T>> {
+    struct flux_sequence_iface {
+    private:
+        struct cursor_type {
+            friend auto operator==(cursor_type, cursor_type) -> bool = default;
+            friend auto operator<=>(cursor_type, cursor_type) = default;
+        };
+
+    public:
+        static constexpr auto first(empty_sequence) -> cursor_type { return {}; }
+        static constexpr auto last(empty_sequence) -> cursor_type { return {}; }
+        static constexpr auto is_last(empty_sequence, cursor_type) -> bool { return true; }
+
+        static constexpr auto inc(empty_sequence, cursor_type& cur, std::ptrdiff_t = 0)
+            -> cursor_type&
+        {
+            return cur;
+        }
+
+        static constexpr auto dec(empty_sequence, cursor_type& cur) -> cursor_type&
+        {
+            return cur;
+        }
+
+        static constexpr auto distance(empty_sequence, cursor_type, cursor_type)
+            -> std::ptrdiff_t
+        {
+            return 0;
+        }
+
+        static constexpr auto size(empty_sequence) -> std::ptrdiff_t { return 0; }
+        static constexpr auto data(empty_sequence) -> T* { return nullptr; }
+
+        static constexpr auto read_at(empty_sequence, cursor_type) -> T&
+        {
+            assert(false && "Attempted read of flux::empty");
+            /* Guaranteed UB... */
+            return *static_cast<T*>(nullptr);
+        }
     };
-
-public:
-    static constexpr auto first() -> cursor_type { return {}; }
-    static constexpr auto last() -> cursor_type { return {}; }
-    static constexpr auto is_last(cursor_type) -> bool { return true; }
-    static constexpr auto inc(cursor_type& cur, std::ptrdiff_t = 0) -> cursor_type& { return cur; }
-    static constexpr auto dec(cursor_type& cur) -> cursor_type& { return cur; }
-    static constexpr auto distance(cursor_type, cursor_type) -> std::ptrdiff_t { return 0; }
-    static constexpr auto size() -> std::ptrdiff_t { return 0; }
-    static constexpr auto data() -> T* { return nullptr; }
-
-    static constexpr auto read_at(cursor_type) -> T&
-    {
-        assert(false && "Attempted read of flux::empty");
-        /* Guaranteed UB... */
-        return *static_cast<T*>(nullptr);
-    }
 };
 
 } // namespace detail

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -51,18 +51,22 @@ struct dummy_impl {
 
 template <typename Elem>
 struct minimal_seq_of {
-    static int first();
-    static bool is_last(int);
-    static int& inc(int&);
-    Elem read_at(int) const;
+    struct flux_sequence_iface {
+        static int first(minimal_seq_of);
+        static bool is_last(minimal_seq_of, int);
+        static int& inc(minimal_seq_of, int&);
+        static Elem read_at(minimal_seq_of, int);
+    };
 };
 
 template <typename Idx>
 struct minimal_with_idx {
-    Idx first();
-    bool is_last(Idx const&);
-    Idx& inc(Idx&);
-    int read_at(Idx const&);
+    struct flux_sequence_iface {
+        static Idx first(minimal_with_idx);
+        static bool is_last(minimal_with_idx, Idx const&);
+        static Idx& inc(minimal_with_idx, Idx&);
+        static int read_at(minimal_with_idx, Idx const&);
+    };
 };
 
 } // end anon namespace
@@ -175,10 +179,12 @@ static_assert(flux::sequence<Derived2>);
 // Adaptable sequence tests
 namespace {
     struct movable_seq {
-        static int first();
-        static bool is_last(int);
-        static int& inc(int&);
-        static int read_at(int);
+        struct flux_sequence_iface {
+            static int first(movable_seq);
+            static bool is_last(movable_seq, int);
+            static int& inc(movable_seq, int&);
+            static int read_at(movable_seq, int);
+        };
     };
 
     struct move_only_seq {
@@ -186,10 +192,12 @@ namespace {
         move_only_seq(move_only_seq&&) = default;
         move_only_seq& operator=(move_only_seq&&) = default;
 
-        static int first();
-        static bool is_last(int);
-        static int& inc(int&);
-        static int read_at(int);
+        struct flux_sequence_iface {
+            static int first(move_only_seq const&);
+            static bool is_last(move_only_seq const&, int);
+            static int& inc(move_only_seq const&, int&);
+            static int read_at(move_only_seq const&, int);
+        };
     };
 
     struct unmovable_seq {
@@ -197,10 +205,12 @@ namespace {
         unmovable_seq(unmovable_seq&&) = delete;
         unmovable_seq& operator=(unmovable_seq&&) = delete;
 
-        static int first();
-        static bool is_last(int);
-        static int& inc(int&);
-        static int read_at(int);
+        struct flux_sequence_iface {
+            static int first(unmovable_seq const&);
+            static bool is_last(unmovable_seq const&, int);
+            static int& inc(unmovable_seq const&, int&);
+            static int read_at(unmovable_seq const&, int);
+        };
     };
 
     static_assert(flux::sequence<movable_seq>);

--- a/test/test_empty.cpp
+++ b/test/test_empty.cpp
@@ -28,4 +28,15 @@ static_assert(flux::is_empty(e));
 }
 
 TEST_CASE("empty")
-{}
+{
+    REQUIRE(e.first() == f.first());
+    REQUIRE(!(e.first() < f.first()));
+    REQUIRE(e.first() == e.last());
+    REQUIRE(e.next(e.first()) == e.last());
+    REQUIRE(e.prev(e.last()) == e.first());
+    REQUIRE(e.size() == 0);
+    REQUIRE(e.distance(e.first(), e.last()) == 0);
+    REQUIRE(e.data() == nullptr);
+    REQUIRE(e.is_empty());
+    REQUIRE(flux::is_empty(e));
+}

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -25,19 +25,27 @@ struct span_seq {
     T* ptr_;
     std::size_t sz_;
 
-    static constexpr std::size_t first() { return 0; }
-    constexpr bool is_last(std::size_t i) const { return i == sz_; }
-    constexpr std::size_t& inc(std::size_t& i) const { return ++i; }
-    constexpr T& read_at(std::size_t i) const { return ptr_[i]; }
-    constexpr std::size_t last() const { return sz_; }
-    static constexpr std::size_t& dec(std::size_t& i) { return --i; }
-    static constexpr std::size_t& inc(std::size_t& i, std::ptrdiff_t o) { return i += o; }
-    static constexpr std::ptrdiff_t distance(std::size_t from, std::size_t to)
-    {
-        return static_cast<std::ptrdiff_t>(to) - static_cast<std::ptrdiff_t>(from);
-    }
-    constexpr std::size_t size() { return sz_; }
-    constexpr T* data() const { return ptr_; }
+    struct flux_sequence_iface {
+        static constexpr std::size_t first(span_seq const&) { return 0; }
+        static constexpr bool is_last(span_seq const& self, std::size_t i) { return i == self.sz_; }
+        static constexpr std::size_t& inc(span_seq const&, std::size_t& i) { return ++i; }
+        static constexpr T& read_at(span_seq const& self, std::size_t i) { return self.ptr_[i]; }
+        static constexpr std::size_t last(span_seq const& self) { return self.sz_; }
+        static constexpr std::size_t& dec(span_seq const&, std::size_t& i) { return --i; }
+        static constexpr std::size_t& inc(span_seq const&, std::size_t& i, std::ptrdiff_t o)
+        {
+            return i += o;
+        }
+        static constexpr std::ptrdiff_t distance(span_seq const&,
+                                                 std::size_t from,
+                                                 std::size_t to)
+        {
+            return static_cast<std::ptrdiff_t>(to) -
+                   static_cast<std::ptrdiff_t>(from);
+        }
+        static constexpr std::size_t size(span_seq const& self) { return self.sz_; }
+        static constexpr T* data(span_seq const& self) { return self.ptr_; }
+    };
 };
 
 constexpr bool test_sort_contexpr()

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -16,12 +16,14 @@ namespace {
 struct ints {
     int from = 0;
 
-    static constexpr int first() { return 0; }
-    static constexpr bool is_last(int) { return false; }
-    constexpr int read_at(int cur) const { return from + cur; }
-    static constexpr int& inc(int& cur, int o = 1) { return cur += o; }
-    static constexpr int& dec(int& cur) { return --cur; }
-    static constexpr int distance(int from, int to) { return to - from; }
+    struct flux_sequence_iface {
+        static constexpr int first(ints) { return 0; }
+        static constexpr bool is_last(ints, int) { return false; }
+        static constexpr int read_at(ints self, int cur){ return self.from + cur; }
+        static constexpr int& inc(ints, int& cur, int o = 1) { return cur += o; }
+        static constexpr int& dec(ints, int& cur) { return --cur; }
+        static constexpr int distance(ints, int from, int to) { return to - from; }
+    };
 };
 
 constexpr bool test_take_while()


### PR DESCRIPTION
Previously (ignoring "simple sequences"), there were two ways of implementing the Sequence protocol:

* Provide a specialisation of sequence_iface<MyType>
* Add a bunch of member functions to MyType with the right names etc

The first case is necessary in order to add Sequence conformance to types we don't own and cannot modify. For types *do* control though, it's a bit of a pain, as the sequence implementation is separate from (and possibly quite distant from) the type to which it pertains.

The second approach of providing member functions is fine for tiny examples, but (at least until we get deducing this) isn't very useful for more complex sequences as we'd have to duplicate everything for const- and non-const fns; and it doesn't interact all that well with inheriting from lens_base, as we can end up hiding names that we would then need to bring back into scope.

This PR replaces the member function approach by instead allowing you to provide a nested class named `MyType::flux_sequence_iface` which has the same format as `sequence_iface<MyType>` -- that is, static methods and nested typedefs etc.

The idea is that this is the best of both worlds: just one way of writing things, but with two options of where to put it (either in-class, or separately).

This has the slight down-side that trivial examples become slightly more verbose, but I don't think any real-world code would actually suffer.