### PR TITLE
Add specialisation for contiguous, sized ranges

### DIFF
--- a/test/test_cache_last.cpp
+++ b/test/test_cache_last.cpp
@@ -32,10 +32,6 @@ constexpr bool test_cache_last()
 
         STATIC_CHECK(cached.size() == 5);
 
-        auto last = flux::last(cached);
-
-        STATIC_CHECK(last == arr.end());
-
         auto view = cached.view();
         static_assert(std::ranges::common_range<decltype(view)>);
     }

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -89,14 +89,14 @@ TEST_CASE("find")
 {
     {
         std::vector<int> vec{1, 2, 3, 4, 5};
-        auto iter = flux::find(vec, 3);
-        REQUIRE(iter == vec.begin() + 2);
+        auto idx = flux::find(vec, 3);
+        REQUIRE(idx == 2);
     }
 
     {
         std::vector<int> vec{1, 2, 3, 4, 5};
-        auto iter = flux::from(vec).find(99);
-        REQUIRE(iter == vec.end());
+        auto idx = flux::from(vec).find(99);
+        REQUIRE(idx == vec.size());
     }
 
 }

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -31,8 +31,6 @@ constexpr bool test_split()
 
         auto split = flux::split(flux::ref(sv), ' ');
 
-        static_assert(flux::detail::has_overloaded_slice<decltype(flux::ref(sv))>);
-
         using S = decltype(split);
 
         static_assert(flux::multipass_sequence<S>);


### PR DESCRIPTION
Uses size_t indices rather than iterators, and saves about a billion template instantiations