### PR TITLE
Add getlines sequence

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -40,6 +40,7 @@
 #include <flux/op/zip.hpp>
 
 #include <flux/source/empty.hpp>
+#include <flux/source/getlines.hpp>
 #include <flux/source/istream.hpp>
 #include <flux/source/istreambuf.hpp>
 #include <flux/source/single.hpp>

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -31,7 +31,7 @@ struct equal_fn {
         while (!flux::is_last(seq1, cur1) && !flux::is_last(seq2, cur2)) {
             if (!std::invoke(cmp, std::invoke(proj1, flux::read_at(seq1, cur1)),
                              std::invoke(proj2, flux::read_at(seq2, cur2)))) {
-                break;
+                return false;
             }
             flux::inc(seq1, cur1);
             flux::inc(seq2, cur2);

--- a/include/flux/source/getlines.hpp
+++ b/include/flux/source/getlines.hpp
@@ -1,0 +1,99 @@
+
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_SOURCE_GETLINES_HPP_INCLUDED
+#define FLUX_SOURCE_GETLINES_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+#include <iosfwd>
+#include <string>
+
+namespace flux {
+
+namespace detail {
+
+template <typename CharT, typename Traits>
+struct getlines_sequence : lens_base<getlines_sequence<CharT, Traits>> {
+private:
+    using istream_type = std::basic_istream<CharT, Traits>;
+    using string_type = std::basic_string<CharT, Traits>;
+    using char_type = CharT;
+
+    istream_type* is_ = nullptr;
+    string_type str_;
+    char_type delim_{};
+
+public:
+    getlines_sequence() = default;
+
+    getlines_sequence(istream_type& is, char_type delim)
+        : is_(std::addressof(is)),
+          delim_(delim)
+    {}
+
+    getlines_sequence(getlines_sequence&&) = default;
+    getlines_sequence& operator=(getlines_sequence&&) = default;
+
+    struct flux_sequence_iface {
+    private:
+        struct cursor_type {
+            explicit cursor_type() = default;
+            cursor_type(cursor_type&&) = default;
+            cursor_type& operator=(cursor_type&&) = default;
+        };
+
+        using self_t = getlines_sequence;
+
+    public:
+        static constexpr auto first(self_t& self) -> cursor_type
+        {
+            cursor_type cur{};
+            inc(self, cur);
+            return cur;
+        }
+
+        static constexpr auto is_last(self_t& self, cursor_type const&) -> bool
+        {
+            return !(self.is_ && static_cast<bool>(*self.is_));
+        }
+
+        static constexpr auto inc(self_t& self, cursor_type& cur) -> cursor_type&
+        {
+            assert(self.is_);
+            if (!std::getline(*self.is_, self.str_, self.delim_)) {
+                self.is_ = nullptr;
+            }
+            return cur;
+        }
+
+        static constexpr auto read_at(self_t& self, cursor_type const&) -> string_type const&
+        {
+            return self.str_;
+        }
+    };
+};
+
+struct getlines_fn {
+    template <typename CharT, typename Traits>
+    constexpr auto operator()(std::basic_istream<CharT, Traits>& istream, CharT delim) const
+    {
+        return getlines_sequence<CharT, Traits>(istream, delim);
+    }
+
+    template <typename CharT, typename Traits>
+    constexpr auto operator()(std::basic_istream<CharT, Traits>& istream) const
+    {
+        return getlines_sequence<CharT, Traits>(istream, istream.widen('\n'));
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto getlines = detail::getlines_fn{};
+
+} // namespace flux
+
+#endif // FLUX_SOURCE_GETLINES_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(test-libflux
 
     test_bitset.cpp
     test_empty.cpp
+    test_getlines.cpp
     test_istream.cpp
     test_istreambuf.cpp
     test_single.cpp

--- a/test/test_getlines.cpp
+++ b/test/test_getlines.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+#include <sstream>
+#include <vector>
+
+constexpr const auto& test_str1 = "Line1\nLine2\nLine3";
+
+TEST_CASE("getlines")
+{
+    std::istringstream iss(test_str1);
+
+    auto seq = flux::getlines(iss);
+
+    static_assert(flux::sequence<decltype(seq)>);
+    static_assert(!flux::multipass_sequence<decltype(seq)>);
+
+    auto cur = seq.first();
+    REQUIRE(seq[cur] == "Line1");
+    seq.inc(cur);
+    REQUIRE(seq[cur] == "Line2");
+    seq.inc(cur);
+    REQUIRE(seq[cur] == "Line3");
+    seq.inc(cur);
+    REQUIRE(seq.is_last(cur));
+}
+
+TEST_CASE("getlines to vector")
+{
+    std::istringstream iss(test_str1);
+
+    auto const vec = flux::getlines(iss).to<std::vector>();
+
+    static_assert(std::same_as<decltype(vec)::value_type, std::string>);
+
+    REQUIRE(vec == std::vector<std::string>{"Line1", "Line2", "Line3"});
+}
+
+TEST_CASE("getlines with custom delimiter")
+{
+    using namespace std::string_view_literals;
+
+    std::istringstream iss("Lorem ipsum dolor sit amet");
+
+    auto seq = flux::getlines(iss, ' ');
+
+    REQUIRE(flux::equal(seq, flux::split_string("Lorem ipsum dolor sit amet"sv, ' ')));
+}
+
+constexpr const auto& test_str2 = L"Line1\nLine2\nLine3";
+
+TEST_CASE("getlines with wide strings")
+{
+    std::wistringstream iss(test_str2);
+
+    auto const vec = flux::getlines(iss).to<std::vector>();
+
+    static_assert(std::same_as<decltype(vec)::value_type, std::wstring>);
+
+    REQUIRE(vec == std::vector<std::wstring>{L"Line1", L"Line2", L"Line3"});
+}


### PR DESCRIPTION
Similar to range-v3, wraps std::getline() in the sequence protocol. Internally re-uses a std::string for each call to getline() to avoid allocations.

The element type of the sequence is std::string const&. Of all the options (prvalue string, string_view, non-const string& etc) it's the best default, as it allows users to make the choice of whether they want to take a copy of the buffer or not, but without many of the lifetime problems of string_view.