### PR TITLE
Make distance_type a library-wide customisation point, not per-sequence

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -139,7 +139,13 @@ struct rvalue_element_type<T> {
 template <typename Seq>
 using value_t = typename detail::value_type<Seq>::type;
 
+#ifdef FLUX_DISTANCE_TYPE
+using distance_t = FLUX_DISTANCE_TYPE;
+static_assert(std::signed_integral<distance_t>,
+              "Custom FLUX_DISTANCE_TYPE must be a signed integer type");
+#else
 using distance_t = std::ptrdiff_t;
+#endif // FLUX_DISTANCE_TYPE
 
 template <typename Seq>
 using rvalue_element_t = typename detail::rvalue_element_type<Seq>::type;

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -89,18 +89,6 @@ template <has_element_type T>
              requires { typename T::value_type; }
 struct value_type<T> { using type = typename T::value_type; };
 
-template <typename>
-struct distance_type { using type = std::ptrdiff_t; };
-
-template <typename T>
-    requires requires { typename iface_t<T>::distance_type; }
-struct distance_type<T> { using type = typename iface_t<T>::distance_type; };
-
-template <typename T>
-    requires requires { iface_t<T>::using_primary_template; } &&
-             requires { typename std::decay_t<T>::distance_type; }
-struct distance_type<T> { using type = typename std::decay_t<T>::distance_type; };
-
 template <has_element_type T>
 struct rvalue_element_type {
     using type = std::conditional_t<std::is_lvalue_reference_v<element_t<T>>,
@@ -125,7 +113,7 @@ template <typename Seq>
 using value_t = typename detail::value_type<Seq>::type;
 
 template <typename Seq>
-using distance_t = typename detail::distance_type<Seq>::type;
+using distance_t = std::ptrdiff_t;
 
 template <typename Seq>
 using rvalue_element_t = typename detail::rvalue_element_type<Seq>::type;

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -112,7 +112,6 @@ struct rvalue_element_type<T> {
 template <typename Seq>
 using value_t = typename detail::value_type<Seq>::type;
 
-template <typename Seq>
 using distance_t = std::ptrdiff_t;
 
 template <typename Seq>
@@ -148,7 +147,6 @@ concept sequence_impl =
     requires (Seq& seq, cursor_t<Seq>& cur) {
         { Iface::inc(seq, cur) } -> std::same_as<cursor_t<Seq>&>;
     } &&
-    std::signed_integral<distance_t<Seq>> &&
     std::common_reference_with<element_t<Seq>&&, rvalue_element_t<Seq>&&>;
     // FIXME FIXME: Need C++23 tuple changes, otherwise zip breaks these
 /*    std::common_reference_with<element_t<Seq>&&, value_t<Seq>&> &&
@@ -195,11 +193,11 @@ namespace detail {
 template <typename Seq, typename Iface = sequence_iface<std::remove_cvref_t<Seq>>>
 concept random_access_sequence_impl =
     bidirectional_sequence<Seq> && ordered_cursor<cursor_t<Seq>> &&
-    requires (Seq& seq, cursor_t<Seq>& cur, distance_t<Seq> offset) {
+    requires (Seq& seq, cursor_t<Seq>& cur, distance_t offset) {
         { Iface::inc(seq, cur, offset) } -> std::same_as<cursor_t<Seq>&>;
     } &&
     requires (Seq& seq, cursor_t<Seq> const& cur) {
-        { Iface::distance(seq, cur, cur) } -> std::convertible_to<distance_t<Seq>>;
+        { Iface::distance(seq, cur, cur) } -> std::convertible_to<distance_t>;
     };
 
 } // namespace detail
@@ -243,7 +241,7 @@ template <typename Seq, typename Iface = sequence_iface<std::remove_cvref_t<Seq>
 concept sized_sequence_impl =
     sequence<Seq> &&
     (requires (Seq& seq) {
-        { Iface::size(seq) } -> std::convertible_to<distance_t<Seq>>;
+        { Iface::size(seq) } -> std::convertible_to<distance_t>;
     } || (
         random_access_sequence<Seq> && bounded_sequence<Seq>
     ));

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -93,7 +93,6 @@ struct sequence_iface<std::reference_wrapper<Seq>> {
     using self_t = std::reference_wrapper<Seq>;
 
     using value_type = value_t<Seq>;
-    using distance_type = distance_t<Seq>;
 
     static constexpr bool disable_multipass = !multipass_sequence<Seq>;
 
@@ -126,7 +125,7 @@ struct sequence_iface<std::reference_wrapper<Seq>> {
         return flux::dec(self.get(), cur);
     }
 
-    static constexpr auto inc(self_t self, cursor_t<Seq>& cur, distance_type offset)
+    static constexpr auto inc(self_t self, cursor_t<Seq>& cur, distance_t offset)
         -> cursor_t<Seq>&
         requires random_access_sequence<Seq>
     {
@@ -135,7 +134,7 @@ struct sequence_iface<std::reference_wrapper<Seq>> {
 
     static constexpr auto distance(self_t self, cursor_t<Seq> const& from,
                                    cursor_t<Seq> const& to)
-        -> distance_type
+        -> distance_t
         requires random_access_sequence<Seq>
     {
         return flux::distance(self.get(), from, to);
@@ -153,7 +152,7 @@ struct sequence_iface<std::reference_wrapper<Seq>> {
         return flux::last(self.get());
     }
 
-    static constexpr auto size(self_t self) -> distance_type
+    static constexpr auto size(self_t self) -> distance_t
         requires sized_sequence<Seq>
     {
         return flux::size(self.get());

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -31,14 +31,14 @@ struct sequence_iface<T[N]> {
 
     static constexpr auto& dec(auto const&, std::size_t& idx) { return --idx; }
 
-    static constexpr auto& inc(auto const&, std::size_t& idx, std::ptrdiff_t offset)
+    static constexpr auto& inc(auto const&, std::size_t& idx, distance_t offset)
     {
-        return idx += offset;
+        return idx += narrow_cast<std::ptrdiff_t>(offset);
     }
 
     static constexpr auto distance(auto const&, std::size_t from, std::size_t to)
     {
-        return static_cast<std::ptrdiff_t>(to) - static_cast<std::ptrdiff_t>(from);
+        return narrow_cast<distance_t>(to) - narrow_cast<distance_t>(from);
     }
 
     static constexpr auto data(auto& self) { return self; }

--- a/include/flux/core/lens_base.hpp
+++ b/include/flux/core/lens_base.hpp
@@ -104,7 +104,11 @@ public:
     [[nodiscard]]
     constexpr auto size() requires sized_sequence<Derived> { return flux::size(derived()); }
 
-    /// Returns true of the sequence contains no elements
+    /// Returns the number of elements in the sequence as a size_t
+    [[nodiscard]]
+    constexpr auto usize() requires sized_sequence<Derived> { return flux::usize(derived()); }
+
+    /// Returns true if the sequence contains no elements
     [[nodiscard]]
     constexpr auto is_empty() requires multipass_sequence<Derived> { return flux::is_empty(derived()); }
 

--- a/include/flux/core/lens_base.hpp
+++ b/include/flux/core/lens_base.hpp
@@ -81,7 +81,7 @@ public:
     /// Increments the given cursor by `offset` places
     template <std::same_as<Derived> D = Derived>
         requires random_access_sequence<Derived>
-    constexpr auto& inc(cursor_t<D>& cur, distance_t<D> offset) { return flux::inc(derived(), cur, offset); }
+    constexpr auto& inc(cursor_t<D>& cur, distance_t offset) { return flux::inc(derived(), cur, offset); }
 
     /// Returns the number of times `from` must be incremented to reach `to`
     ///
@@ -125,8 +125,8 @@ public:
             requires bounded_sequence<Derived> ||
                      (multipass_sequence<Derived> && not infinite_sequence<Derived>);
 
-    template <std::same_as<Derived> D = Derived>
-    constexpr auto drop(distance_t<D> count) &&;
+    [[nodiscard]]
+    constexpr auto drop(distance_t count) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>
@@ -160,9 +160,8 @@ public:
     [[nodiscard]]
     constexpr auto split_string(Pattern&& pattern) &&;
 
-    template <std::same_as<Derived> D = Derived>
     [[nodiscard]]
-    constexpr auto take(distance_t<D> count) &&;
+    constexpr auto take(distance_t count) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -125,6 +125,15 @@ struct size_fn {
     }
 };
 
+struct usize_fn {
+    template <sized_sequence Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq& seq) const -> std::size_t
+    {
+        return narrow_cast<std::size_t>(size_fn{}(seq));
+    }
+};
+
 struct unchecked_move_at_fn {
     template <sequence Seq>
     [[nodiscard]]
@@ -242,6 +251,7 @@ inline constexpr auto distance = detail::distance_fn{};
 inline constexpr auto data = detail::data_fn{};
 inline constexpr auto last = detail::last_fn{};
 inline constexpr auto size = detail::size_fn{};
+inline constexpr auto usize = detail::usize_fn{};
 inline constexpr auto checked_read_at = detail::checked_read_at_fn{};
 inline constexpr auto checked_move_at = detail::checked_move_at_fn{};
 inline constexpr auto checked_inc = detail::checked_inc_fn{};

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -54,7 +54,7 @@ struct unchecked_inc_fn {
 
     template <random_access_sequence Seq>
     constexpr auto operator()(Seq& seq, cursor_t<Seq>& cur,
-                              distance_t<Seq> offset) const
+                              distance_t offset) const
         noexcept(noexcept(iface_t<Seq>::inc(seq, cur, offset))) -> cursor_t<Seq>&
     {
         return iface_t<Seq>::inc(seq, cur, offset);
@@ -75,12 +75,12 @@ struct distance_fn {
     [[nodiscard]]
     constexpr auto operator()(Seq& seq, cursor_t<Seq> const& from,
                                             cursor_t<Seq> const& to) const
-        -> distance_t<Seq>
+        -> distance_t
     {
         if constexpr (random_access_sequence<Seq>) {
             return iface_t<Seq>::distance(seq, from, to);
         } else {
-            distance_t<Seq> n = 0;
+            distance_t n = 0;
             auto from_ = from;
             while (from_ != to) {
                 unchecked_inc_fn{}(seq, from_);
@@ -114,7 +114,7 @@ struct last_fn {
 struct size_fn {
     template <sized_sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq& seq) const -> distance_t<Seq>
+    constexpr auto operator()(Seq& seq) const -> distance_t
     {
         if constexpr (requires { iface_t<Seq>::size(seq); }) {
             return iface_t<Seq>::size(seq);
@@ -149,8 +149,8 @@ struct check_bounds_fn {
     constexpr bool operator()(Seq& seq, cursor_t<Seq> const& cur) const
     {
         if constexpr (random_access_sequence<Seq>) {
-            distance_t<Seq> dist = distance_fn{}(seq, first_fn{}(seq), cur);
-            if (dist < distance_t<Seq>{0}) {
+            distance_t dist = distance_fn{}(seq, first_fn{}(seq), cur);
+            if (dist < distance_t{0}) {
                 return false;
             }
             if constexpr (sized_sequence<Seq>) {
@@ -201,7 +201,7 @@ struct checked_inc_fn {
     }
 
     template <random_access_sequence Seq>
-    constexpr auto operator()(Seq& seq, cursor_t<Seq>& cur, distance_t<Seq> offset) const
+    constexpr auto operator()(Seq& seq, cursor_t<Seq>& cur, distance_t offset) const
         -> cursor_t<Seq>&
     {
         const auto dist = distance_fn{}(seq, first_fn{}(seq), cur);
@@ -273,13 +273,13 @@ struct next_fn {
 
     template <sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq& seq, cursor_t<Seq> cur, distance_t<Seq> offset) const
+    constexpr auto operator()(Seq& seq, cursor_t<Seq> cur, distance_t offset) const
         -> cursor_t<Seq>
     {
         if constexpr (random_access_sequence<Seq>) {
             return inc(seq, cur, offset);
         } else if constexpr (bidirectional_sequence<Seq>) {
-            const auto zero = distance_t<Seq>{0};
+            auto const zero = distance_t{0};
             if (offset > zero) {
                 while (offset-- > zero) {
                     inc(seq, cur);
@@ -291,7 +291,7 @@ struct next_fn {
             }
             return cur;
         } else {
-            while (offset-- > distance_t<Seq>{0}) {
+            while (offset-- > distance_t{0}) {
                 inc(seq, cur);
             }
             return cur;

--- a/include/flux/op/cartesian_product.hpp
+++ b/include/flux/op/cartesian_product.hpp
@@ -49,9 +49,6 @@ inline constexpr bool cartesian_product_is_bounded = bounded_sequence<B0>;
 
 template <typename... Bases>
 struct cartesian_product_iface_base {
-
-    using distance_type = std::common_type_t<distance_t<Bases>...>;
-
 private:
     template <typename From, typename To>
     using const_like_t = std::conditional_t<std::is_const_v<From>, To const, To>;
@@ -90,7 +87,7 @@ private:
     }
 
     template <std::size_t I, typename Self>
-    static constexpr auto ra_inc_impl(Self& self, cursor_type<Self>& cur, distance_type offset)
+    static constexpr auto ra_inc_impl(Self& self, cursor_type<Self>& cur, distance_t offset)
     -> cursor_type<Self>&
     {
         auto& base = std::get<I>(self.bases_);
@@ -115,7 +112,7 @@ private:
     template <std::size_t I, typename Self>
     static constexpr auto distance_impl(Self& self,
                                         cursor_type<Self> const& from,
-                                        cursor_type<Self> const& to) -> distance_type
+                                        cursor_type<Self> const& to) -> distance_t
     {
         if constexpr (I == 0) {
             return flux::distance(std::get<0>(self.bases_), std::get<0>(from), std::get<0>(to));
@@ -170,7 +167,7 @@ public:
     template <typename Self>
     requires (random_access_sequence<const_like_t<Self, Bases>> && ...) &&
              (sized_sequence<const_like_t<Self, Bases>> && ...)
-    static constexpr auto inc(Self& self, cursor_type<Self>& cur, distance_type offset)
+    static constexpr auto inc(Self& self, cursor_type<Self>& cur, distance_t offset)
     -> cursor_type<Self>&
     {
         return ra_inc_impl<sizeof...(Bases) - 1>(self, cur, offset);
@@ -181,17 +178,17 @@ public:
              (sized_sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto distance(Self& self,
                                    cursor_type<Self> const& from,
-                                   cursor_type<Self> const& to) -> distance_type
+                                   cursor_type<Self> const& to) -> distance_t
     {
         return distance_impl<sizeof...(Bases) - 1>(self, from, to);
     }
 
     template <typename Self>
         requires (sized_sequence<const_like_t<Self, Bases>> && ...)
-    static constexpr auto size(Self& self) -> distance_type
+    static constexpr auto size(Self& self) -> distance_t
     {
         return std::apply([](auto&... base) {
-          return (static_cast<distance_type>(flux::size(base)) * ...);
+          return (flux::size(base) * ...);
         }, self.bases_);
     }
 };

--- a/include/flux/op/chain.hpp
+++ b/include/flux/op/chain.hpp
@@ -61,7 +61,6 @@ template <typename... Bases>
 struct sequence_iface<detail::chain_adaptor<Bases...>> {
 
     using value_type = std::common_type_t<value_t<Bases>...>;
-    using distance_type = std::common_type_t<distance_t<Bases>...>;
 
     static constexpr bool disable_multipass = !(multipass_sequence<Bases> && ...);
     static constexpr bool is_infinite = (infinite_sequence<Bases> || ...);
@@ -219,7 +218,7 @@ private:
 
     template <std::size_t N, typename Self>
     static constexpr auto inc_ra_impl(Self& self, cursor_type<Self>& cur,
-                                      distance_type offset)
+                                      distance_t offset)
         -> cursor_type<Self>&
     {
         if constexpr (N < End) {
@@ -315,7 +314,7 @@ public:
     template <typename Self>
     static constexpr auto distance(Self& self, cursor_type<Self> const& from,
                                    cursor_type<Self> const& to)
-        -> distance_type
+        -> distance_t
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...) &&
                  (bounded_sequence<const_like_t<Self, Bases>> && ...)
     {
@@ -327,7 +326,7 @@ public:
     }
 
     template <typename Self>
-    static constexpr auto inc(Self& self, cursor_type<Self>& cur, distance_type offset)
+    static constexpr auto inc(Self& self, cursor_type<Self>& cur, distance_t offset)
         -> cursor_type<Self>&
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...) &&
                  (bounded_sequence<const_like_t<Self, Bases>> && ...)

--- a/include/flux/op/count.hpp
+++ b/include/flux/op/count.hpp
@@ -15,12 +15,12 @@ namespace detail {
 struct count_fn {
     template <sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> distance_t<Seq>
+    constexpr auto operator()(Seq&& seq) const -> distance_t
     {
         if constexpr (sized_sequence<Seq>) {
             return flux::size(seq);
         } else {
-            distance_t<Seq> counter = 0;
+            distance_t counter = 0;
             flux::for_each_while(seq, [&](auto&&) {
                 ++counter;
                 return true;
@@ -33,9 +33,9 @@ struct count_fn {
         requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Value const& value, Proj proj = {}) const
-        -> distance_t<Seq>
+        -> distance_t
     {
-        distance_t<Seq> counter = 0;
+        distance_t counter = 0;
         flux::for_each_while(seq, [&](auto&& elem) {
             if (value == std::invoke(proj, FLUX_FWD(elem))) {
                 ++counter;
@@ -51,9 +51,9 @@ struct count_if_fn {
         requires predicate_for<Pred, Seq, Proj>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred, Proj proj = {}) const
-        -> distance_t<Seq>
+        -> distance_t
     {
-        distance_t<Seq> counter = 0;
+        distance_t counter = 0;
         flux::for_each_while(seq, [&](auto&& elem) {
             if (std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)))) {
                 ++counter;

--- a/include/flux/op/detail/heap_ops.hpp
+++ b/include/flux/op/detail/heap_ops.hpp
@@ -33,7 +33,7 @@
 namespace flux::detail {
 
 template <typename Seq, typename Comp, typename Proj>
-constexpr void sift_up_n(Seq& seq, distance_t<Seq> n, Comp& comp, Proj& proj)
+constexpr void sift_up_n(Seq& seq, distance_t n, Comp& comp, Proj& proj)
 {
     cursor_t<Seq> first = flux::first(seq);
 
@@ -60,7 +60,7 @@ constexpr void sift_up_n(Seq& seq, distance_t<Seq> n, Comp& comp, Proj& proj)
 }
 
 template <typename Seq, typename Comp, typename Proj>
-constexpr void sift_down_n(Seq& seq, distance_t<Seq> n, cursor_t<Seq> start,
+constexpr void sift_down_n(Seq& seq, distance_t n, cursor_t<Seq> start,
                            Comp& comp, Proj& proj)
 {
     cursor_t<Seq> first = flux::first(seq);
@@ -123,7 +123,7 @@ constexpr void sift_down_n(Seq& seq, distance_t<Seq> n, cursor_t<Seq> start,
 template <sequence Seq, typename Comp, typename Proj >
 constexpr void make_heap(Seq& seq, Comp& comp, Proj& proj)
 {
-    distance_t<Seq> n = flux::size(seq);
+    distance_t n = flux::size(seq);
     auto first = flux::first(seq);
 
     if (n > 1) {
@@ -134,7 +134,7 @@ constexpr void make_heap(Seq& seq, Comp& comp, Proj& proj)
 }
 
 template <sequence Seq, typename Comp, typename Proj>
-constexpr void pop_heap(Seq& seq, distance_t<Seq> n, Comp& comp, Proj& proj)
+constexpr void pop_heap(Seq& seq, distance_t n, Comp& comp, Proj& proj)
 {
     auto first = flux::first(seq);
     if (n > 1) {

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -323,14 +323,14 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
         start_l += num;
         start_r += num;
         if (num_l == 0)
-            first += pdqsort_block_size;
+            inc(seq, first, pdqsort_block_size);
         if (num_r == 0)
-            last -= pdqsort_block_size;
+            inc(seq, last, -pdqsort_block_size);
     }
 
     distance_t l_size = 0, r_size = 0;
     distance_t unknown_left =
-        (last - first) - ((num_r || num_l) ? pdqsort_block_size : 0);
+        distance(seq, first, last) - ((num_r || num_l) ? pdqsort_block_size : 0);
     if (num_r) {
         // Handle leftover block by assigning the unknown elements to the other
         // block.
@@ -372,9 +372,9 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
     start_l += num;
     start_r += num;
     if (num_l == 0)
-        first += l_size;
+        inc(seq, first, l_size);
     if (num_r == 0)
-        last -= r_size;
+        inc(seq, last, -r_size);
 
     // We have now fully identified [first, last)'s proper position. Swap the
     // last elements.

--- a/include/flux/op/detail/pdqsort.hpp
+++ b/include/flux/op/detail/pdqsort.hpp
@@ -134,7 +134,7 @@ constexpr bool partial_insertion_sort(Seq& seq, Cur const begin, Cur const end, 
         return true;
     }
 
-    distance_t<Seq> limit = 0;
+    distance_t limit = 0;
 
     for (auto cur = next(seq, begin); cur != end; inc(seq, cur)) {
         if (limit > pqdsort_partial_insertion_sort_limit) {
@@ -328,8 +328,8 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
             last -= pdqsort_block_size;
     }
 
-    distance_t<Seq> l_size = 0, r_size = 0;
-    distance_t<Seq> unknown_left =
+    distance_t l_size = 0, r_size = 0;
+    distance_t unknown_left =
         (last - first) - ((num_r || num_l) ? pdqsort_block_size : 0);
     if (num_r) {
         // Handle leftover block by assigning the unknown elements to the other
@@ -349,7 +349,7 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
     if (unknown_left && !num_l) {
         start_l = 0;
         Cur cur = first;
-        for (unsigned char i = 0; static_cast<distance_t<Seq>>(i) < l_size;) {
+        for (unsigned char i = 0; static_cast<distance_t>(i) < l_size;) {
             offsets_l[num_l] = i++;
             num_l += !comp(read_at(seq, cur), pivot);
             inc(seq, cur);
@@ -358,7 +358,7 @@ partition_right_branchless(Seq& seq, Cur const begin, Cur const end, Comp& comp)
     if (unknown_left && !num_r) {
         start_r = 0;
         Cur cur = last;
-        for (unsigned char i = 0; static_cast<distance_t<Seq>>(i) < r_size;) {
+        for (unsigned char i = 0; static_cast<distance_t>(i) < r_size;) {
             offsets_r[num_r] = ++i;
             num_r += comp(read_at(seq, dec(seq, cur)), pivot);
         }
@@ -502,8 +502,7 @@ template <bool Branchless, typename Seq, typename Comp,
 constexpr void pdqsort_loop(Seq& seq, Cur begin, Cur end, Comp& comp,
                             int bad_allowed, bool leftmost = true)
 {
-    //using diff_t = iter_difference_t<I>
-    using diff_t = distance_t<Seq>;
+    using diff_t = distance_t;
 
     // Use a while loop for tail recursion elimination.
     while (true) {

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -19,11 +19,11 @@ template <sequence Base>
 struct drop_adaptor : lens_base<drop_adaptor<Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
-    distance_t<Base> count_;
+    distance_t count_;
     std::optional<cursor_t<Base>> cached_first_;
 
 public:
-    constexpr drop_adaptor(decays_to<Base> auto&& base, distance_t<Base> count)
+    constexpr drop_adaptor(decays_to<Base> auto&& base, distance_t count)
         : base_(FLUX_FWD(base)),
           count_(count)
     {}
@@ -33,7 +33,6 @@ public:
 
     struct flux_sequence_iface : passthrough_iface_base<drop_adaptor> {
         using value_type = value_t<Base>;
-        using distance_type = distance_t<Base>;
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
@@ -69,7 +68,7 @@ public:
 struct drop_fn {
     template <adaptable_sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, distance_t<Seq> count) const
+    constexpr auto operator()(Seq&& seq, distance_t count) const
     {
         return drop_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count);
     }
@@ -81,8 +80,7 @@ struct drop_fn {
 inline constexpr auto drop = detail::drop_fn{};
 
 template <typename Derived>
-template <std::same_as<Derived> D>
-constexpr auto lens_base<Derived>::drop(distance_t<D> count) &&
+constexpr auto lens_base<Derived>::drop(distance_t count) &&
 {
     return detail::drop_adaptor<Derived>(std::move(derived()), count);
 }

--- a/include/flux/op/output_to.hpp
+++ b/include/flux/op/output_to.hpp
@@ -43,8 +43,8 @@ public:
                 return impl(seq, iter);
             } else {
                 std::memmove(std::to_address(iter), flux::data(seq),
-                             flux::size(seq) * sizeof(value_t<Seq>));
-                return iter + flux::size(seq);
+                             flux::usize(seq) * sizeof(value_t<Seq>));
+                return iter + narrow_cast<std::iter_difference_t<Iter>>(flux::size(seq));
             }
         } else {
             return impl(seq, iter);

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -87,8 +87,6 @@ struct passthrough_iface_base {
     template <typename Self>
     using cursor_t = decltype(flux::first(FLUX_DECLVAL(Self&).base()));
 
-    using distance_type = distance_t<Base>;
-
     static constexpr auto first(auto& self)
         -> decltype(flux::first(self.base()))
     {
@@ -124,7 +122,7 @@ struct passthrough_iface_base {
     }
 
     template <typename Self>
-    static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_type dist)
+    static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_t dist)
         -> decltype(flux::inc(self.base(), cur, dist))
     {
         return flux::unchecked_inc(self.base(), cur, dist);

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -120,7 +120,7 @@ struct sequence_iface<detail::reverse_adaptor<Base>>
     static constexpr auto distance(auto& self, auto const& from, auto const& to)
         requires random_access_sequence<decltype(self.base_)>
     {
-        return -flux::distance(self.base_, from.base_cur, to.base_cur);
+        return flux::distance(self.base_, to.base_cur, from.base_cur);
     }
 
     // FIXME: GCC11 ICE

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -77,7 +77,6 @@ template <typename Base>
 struct sequence_iface<detail::reverse_adaptor<Base>>
 {
     using value_type = value_t<Base>;
-    using distance_type = distance_t<Base>;
 
     static constexpr auto first(auto& self)
     {

--- a/include/flux/op/split_string.hpp
+++ b/include/flux/op/split_string.hpp
@@ -25,7 +25,7 @@ struct to_string_view_fn {
         requires sized_sequence<Seq> && character<value_t<Seq>>
     constexpr auto operator()(Seq&& seq) const
     {
-        return std::basic_string_view<value_t<Seq>>(flux::data(seq), flux::size(seq));
+        return std::basic_string_view<value_t<Seq>>(flux::data(seq), flux::usize(seq));
     }
 };
 

--- a/include/flux/op/take.hpp
+++ b/include/flux/op/take.hpp
@@ -19,7 +19,7 @@ struct take_adaptor : lens_base<take_adaptor<Base>>
 {
 private:
     Base base_;
-    distance_t<Base> count_;
+    distance_t count_;
 
     template <bool IsConst>
     struct cursor_type {
@@ -28,7 +28,7 @@ private:
 
     public:
         cursor_t<base_t> base_cur;
-        distance_t<base_t> length;
+        distance_t length;
 
         friend bool operator==(cursor_type const&, cursor_type const&) = default;
         friend auto operator<=>(cursor_type const& lhs, cursor_type const& rhs) = default;
@@ -37,7 +37,7 @@ private:
     friend struct sequence_iface<take_adaptor>;
 
 public:
-    constexpr take_adaptor(decays_to<Base> auto&& base, distance_t<Base> count)
+    constexpr take_adaptor(decays_to<Base> auto&& base, distance_t count)
         : base_(FLUX_FWD(base)),
           count_(count)
     {}
@@ -50,7 +50,7 @@ struct take_fn {
 
     template <adaptable_sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, distance_t<Seq> count) const
+    constexpr auto operator()(Seq&& seq, distance_t count) const
     {
         if constexpr (random_access_sequence<Seq> && std::is_lvalue_reference_v<Seq>) {
             auto first = flux::first(seq);
@@ -72,7 +72,6 @@ struct sequence_iface<detail::take_adaptor<Base>> {
         typename std::remove_const_t<Self>::template cursor_type<std::is_const_v<Self>>;
 
     using value_type = value_t<Base>;
-    using distance_type = distance_t<Base>;
 
     static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
@@ -116,7 +115,7 @@ struct sequence_iface<detail::take_adaptor<Base>> {
     }
 
     template <typename Self>
-    static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_t<Base> offset)
+    static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_t offset)
         -> cursor_t<Self>&
         requires random_access_sequence<Base>
     {
@@ -167,10 +166,9 @@ struct sequence_iface<detail::take_adaptor<Base>> {
 inline constexpr auto take = detail::take_fn{};
 
 template <typename Derived>
-template <std::same_as<Derived> D>
-constexpr auto lens_base<Derived>::take(distance_t<D> count) &&
+constexpr auto lens_base<Derived>::take(distance_t count) &&
 {
-    return detail::take_adaptor<D>(std::move(derived()), count);
+    return detail::take_adaptor<Derived>(std::move(derived()), count);
 }
 
 } // namespace flux

--- a/include/flux/op/to.hpp
+++ b/include/flux/op/to.hpp
@@ -150,7 +150,7 @@ constexpr auto to(Seq&& seq, Args&&... args) -> Container
         } else {
             auto c = Container(FLUX_FWD(args)...);
             if constexpr (sized_sequence<Seq> && detail::reservable_container<Container>) {
-                c.reserve(flux::size(seq));
+                c.reserve(flux::usize(seq));
             }
             flux::output_to(seq, detail::make_inserter<element_t<Seq>>(c));
             return c;

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -78,7 +78,6 @@ private:
 
 public:
     using value_type = tuple_t<value_t<Bases>...>;
-    using distance_type = std::common_type_t<distance_t<Bases>...>;
 
     static constexpr bool is_infinite = (infinite_sequence<Bases> && ...);
 
@@ -129,7 +128,7 @@ public:
     }
 
     template <typename Self>
-    static constexpr auto& inc(Self& self, cursor_t<Self>& cur, distance_t<Self> offset)
+    static constexpr auto& inc(Self& self, cursor_t<Self>& cur, distance_t offset)
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
     {
         [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -145,9 +144,7 @@ public:
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
     {
         return [&]<std::size_t... I>(std::index_sequence<I...>) {
-            return std::min({
-                static_cast<distance_t<Self>>(
-                    flux::distance(std::get<I>(self.bases_), std::get<I>(from), std::get<I>(to)))...});
+            return std::min({flux::distance(std::get<I>(self.bases_), std::get<I>(from), std::get<I>(to))...});
         }(std::index_sequence_for<Bases...>{});
     }
 
@@ -165,7 +162,7 @@ public:
         requires (sized_sequence<const_like_t<Self, Bases>> && ...)
     {
         return std::apply([&](auto&... args) {
-            return std::min({static_cast<distance_t<Self>>(flux::size(args))...});
+            return std::min({flux::size(args)...});
         }, self.bases_);
     }
 

--- a/include/flux/ranges/from_range.hpp
+++ b/include/flux/ranges/from_range.hpp
@@ -70,7 +70,7 @@ struct sequence_iface<R> {
     static constexpr auto inc(Self&, cursor_t<Self>& cur, distance_t offset)
         -> cursor_t<Self>&
     {
-        return cur += offset;
+        return cur += narrow_cast<std::ranges::range_difference_t<Self>>(offset);
     }
 
     template <decays_to<R> Self>
@@ -198,14 +198,14 @@ struct sequence_iface<R> {
         requires std::ranges::range<Self>
     static constexpr auto inc(Self&, cursor_type& cur, distance_t off) -> cursor_type&
     {
-        return cur += off;
+        return cur += narrow_cast<std::ptrdiff_t>(off);
     }
 
     template <decays_to<R> Self>
         requires std::ranges::range<Self>
     static constexpr auto distance(Self&, cursor_type from, cursor_type to) -> distance_t
     {
-        return static_cast<distance_t>(to - from);
+        return narrow_cast<distance_t>(to) - narrow_cast<distance_t>(from);
     }
 
     template <decays_to<R> Self>

--- a/include/flux/ranges/from_range.hpp
+++ b/include/flux/ranges/from_range.hpp
@@ -26,7 +26,6 @@ template <typename R>
 struct sequence_iface<R> {
 
     using value_type = std::ranges::range_value_t<R>;
-    using distance_type = std::ranges::range_difference_t<R>;
 
     static constexpr bool disable_multipass = !std::ranges::forward_range<R>;
 
@@ -68,7 +67,7 @@ struct sequence_iface<R> {
 
     template <decays_to<R> Self>
         requires std::random_access_iterator<cursor_t<Self>>
-    static constexpr auto inc(Self&, cursor_t<Self>& cur, distance_t<Self> offset)
+    static constexpr auto inc(Self&, cursor_t<Self>& cur, distance_t offset)
         -> cursor_t<Self>&
     {
         return cur += offset;
@@ -145,7 +144,6 @@ struct sequence_iface<R> {
 
     using cursor_type = std::ranges::range_size_t<R>;
     using value_type = std::ranges::range_value_t<R>;
-    using distance_type = std::ranges::range_difference_t<R>;
 
     template <decays_to<R> Self>
         requires std::ranges::range<Self>
@@ -198,16 +196,16 @@ struct sequence_iface<R> {
 
     template <decays_to<R> Self>
         requires std::ranges::range<Self>
-    static constexpr auto inc(Self&, cursor_type& cur, distance_type off) -> cursor_type&
+    static constexpr auto inc(Self&, cursor_type& cur, distance_t off) -> cursor_type&
     {
         return cur += off;
     }
 
     template <decays_to<R> Self>
         requires std::ranges::range<Self>
-    static constexpr auto distance(Self&, cursor_type from, cursor_type to) -> distance_type
+    static constexpr auto distance(Self&, cursor_type from, cursor_type to) -> distance_t
     {
-        return static_cast<distance_type>(to - from);
+        return static_cast<distance_t>(to - from);
     }
 
     template <decays_to<R> Self>

--- a/include/flux/ranges/view.hpp
+++ b/include/flux/ranges/view.hpp
@@ -45,7 +45,7 @@ private:
 
     public:
         using value_type = value_t<S>;
-        using difference_type = distance_t<S>;
+        using difference_type = distance_t;
         using element_type = value_t<S>;
         using iterator_concept = decltype(get_iterator_tag<S>());
 

--- a/include/flux/source/empty.hpp
+++ b/include/flux/source/empty.hpp
@@ -29,7 +29,7 @@ struct empty_sequence : lens_base<empty_sequence<T>> {
         static constexpr auto last(empty_sequence) -> cursor_type { return {}; }
         static constexpr auto is_last(empty_sequence, cursor_type) -> bool { return true; }
 
-        static constexpr auto inc(empty_sequence, cursor_type& cur, std::ptrdiff_t = 0)
+        static constexpr auto inc(empty_sequence, cursor_type& cur, distance_t = 0)
             -> cursor_type&
         {
             return cur;

--- a/include/flux/source/single.hpp
+++ b/include/flux/source/single.hpp
@@ -95,7 +95,7 @@ public:
         return cur;
     }
 
-    static constexpr auto inc(self_t const&, cursor_type& cur, std::ptrdiff_t off)
+    static constexpr auto inc(self_t const&, cursor_type& cur, distance_t off)
         -> cursor_type&
     {
         if (off > 0) {

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -32,16 +32,13 @@ struct span_seq {
         static constexpr T& read_at(span_seq const& self, std::size_t i) { return self.ptr_[i]; }
         static constexpr std::size_t last(span_seq const& self) { return self.sz_; }
         static constexpr std::size_t& dec(span_seq const&, std::size_t& i) { return --i; }
-        static constexpr std::size_t& inc(span_seq const&, std::size_t& i, std::ptrdiff_t o)
+        static constexpr std::size_t& inc(span_seq const&, std::size_t& i, flux::distance_t o)
         {
-            return i += o;
+            return i += static_cast<std::size_t>(o);
         }
-        static constexpr std::ptrdiff_t distance(span_seq const&,
-                                                 std::size_t from,
-                                                 std::size_t to)
+        static constexpr flux::distance_t distance(span_seq const&, std::size_t from, std::size_t to)
         {
-            return static_cast<std::ptrdiff_t>(to) -
-                   static_cast<std::ptrdiff_t>(from);
+            return static_cast<flux::distance_t>(to) - static_cast<flux::distance_t>(from);
         }
         static constexpr std::size_t size(span_seq const& self) { return self.sz_; }
         static constexpr T* data(span_seq const& self) { return self.ptr_; }

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -19,7 +19,7 @@ namespace {
 
 constexpr auto  to_string_view = []<typename Seq>(Seq&& seq) // danger Will Robinson
 {
-    return std::basic_string_view<flux::value_t<Seq>>(flux::data(seq), flux::size(seq));
+    return std::basic_string_view<flux::value_t<Seq>>(flux::data(seq), flux::usize(seq));
 };
 
 constexpr bool test_split()


### PR DESCRIPTION
Like Ranges' `difference_type`, Flux currently allows sequences to specify their own `distance_type` which is used to count things and specify offsets and things like that.

Only... there doesn't actually seem a lot that's gained by doing so, as everything just uses `ptrdiff_t` anyway, and it brings complications in terms of working out the distance type of things like `chain` and `zip`.

So what we'll do instead is to allow customising the `distance_type` for the library as a whole, rather than per-sequence.