### PR TITLE
Add seq._(fn, args...) member function

### DIFF
--- a/include/flux/core/lens_base.hpp
+++ b/include/flux/core/lens_base.hpp
@@ -121,6 +121,34 @@ public:
     [[nodiscard]]
     constexpr auto prev(cursor_t<D> cur) { return flux::prev(derived(), cur); }
 
+    template <typename Func, typename... Args>
+        requires std::invocable<Func, Derived&, Args...>
+    constexpr auto _(Func&& func, Args&&... args) & -> decltype(auto)
+    {
+        return std::invoke(FLUX_FWD(func), derived(), FLUX_FWD(args)...);
+    }
+
+    template <typename Func, typename... Args>
+        requires std::invocable<Func, Derived const&, Args...>
+    constexpr auto _(Func&& func, Args&&... args) const& -> decltype(auto)
+    {
+        return std::invoke(FLUX_FWD(func), derived(), FLUX_FWD(args)...);
+    }
+
+    template <typename Func, typename... Args>
+        requires std::invocable<Func, Derived, Args...>
+    constexpr auto _(Func&& func, Args&&... args) && -> decltype(auto)
+    {
+        return std::invoke(FLUX_FWD(func), std::move(derived()), FLUX_FWD(args)...);
+    }
+
+    template <typename Func, typename... Args>
+        requires std::invocable<Func, Derived const, Args...>
+    constexpr auto _(Func&& func, Args&&... args) const&& -> decltype(auto)
+    {
+        return std::invoke(FLUX_FWD(func), std::move(derived()), FLUX_FWD(args)...);
+    }
+
     /*
      * Adaptors
      */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(test-libflux
 
     test_concepts.cpp
     test_simple_sequence.cpp
+    test_apply.cpp
 
     test_all_any_none.cpp
     test_bounds_checked.cpp

--- a/test/test_apply.cpp
+++ b/test/test_apply.cpp
@@ -1,0 +1,68 @@
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include <array>
+#include <algorithm>
+
+#include "test_utils.hpp"
+
+// We don't have an in-place rotate yet, so let's borrow the STL's
+auto rotate_by = []<flux::random_access_sequence Seq>(Seq&& seq, flux::distance_t places)
+    -> Seq&&
+{
+    auto const sz = flux::size(seq);
+
+    while (places < 0) {
+        places += sz;
+    }
+    while (places >= sz) {
+        places -= sz;
+    }
+
+    auto view = flux::view(seq);
+    std::ranges::rotate(view, view.begin() + places);
+
+    return FLUX_FWD(seq);
+};
+
+
+constexpr bool test_apply()
+{
+    // Checking lvalue sequence
+    {
+        auto seq = flux::from(std::array{1, 2, 3, 4, 5});
+        auto& r = seq._(rotate_by, -1);
+        STATIC_CHECK(&r == &seq);
+        STATIC_CHECK(check_equal(seq, {5, 1, 2, 3, 4}));
+    }
+
+    // Checking rvalue sequence
+    {
+        auto seq = flux::from(std::array{1, 2, 3, 4, 5})._(rotate_by, -1).take(3);
+        STATIC_CHECK(check_equal(seq, {5, 1, 2}));
+    }
+
+    // Checking const [l|r]value
+    {
+        auto sum = [](auto& seq) {
+            int s = 0;
+            FLUX_FOR(int i, seq) { s += i; }
+            return s;
+        };
+
+        auto const seq = flux::from(std::array{1, 2, 3, 4, 5});
+        STATIC_CHECK(seq._(sum) == 15);
+
+        STATIC_CHECK(std::move(seq)._(sum) == 15);
+    }
+
+    return true;
+}
+static_assert(test_apply());
+
+TEST_CASE("apply")
+{
+    REQUIRE(test_apply());
+}


### PR DESCRIPTION
This allows adding custom operations as part of a pipeline using the "dot" syntax, for example

    auto res = get_sequence()
                .filter(...)
                .map(...)
                ._(custom_op, arg1, arg2)
                .fold(...)

which will call `custom_user_op(seq, arg1, arg2)` with the adapted sequence as the first argument, followed by the provided args.

I previously had this in Flow as `x.apply(fn, args...)`, but Barry's idea from his Rivers library to name it just `x._(fn, args...)` is much better.