### PR TITLE
Add iota source

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -43,6 +43,7 @@
 
 #include <flux/source/empty.hpp>
 #include <flux/source/getlines.hpp>
+#include <flux/source/iota.hpp>
 #include <flux/source/istream.hpp>
 #include <flux/source/istreambuf.hpp>
 #include <flux/source/single.hpp>

--- a/include/flux/source/iota.hpp
+++ b/include/flux/source/iota.hpp
@@ -1,0 +1,194 @@
+
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_SOURCE_IOTA_HPP_INCLUDED
+#define FLUX_SOURCE_IOTA_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+namespace flux {
+
+namespace detail {
+
+// These concepts mirror the standard ones, except that iter_difference_t is not required
+template <typename T>
+concept incrementable =
+    std::regular<T> &&
+    requires (T t) {
+        { ++t } -> std::same_as<T&>;
+        { t++ } -> std::same_as<T>;
+    };
+
+template <typename T>
+concept decrementable =
+    incrementable<T> &&
+    requires (T t) {
+        { --t } -> std::same_as<T&>;
+        { t-- } -> std::same_as<T>;
+    };
+
+template <typename T>
+concept advancable =
+    decrementable<T> &&
+    std::totally_ordered<T> &&
+    std::weakly_incrementable<T> && // iter_difference_t exists
+    requires (T t, T const u, std::iter_difference_t<T> o) {
+        { t += o } -> std::same_as<T&>;
+        { t -= o } -> std::same_as<T&>;
+        T(u + o);
+        T(o + u);
+        T(u - o);
+        { u - u } -> std::convertible_to<distance_t>;
+    };
+
+struct iota_traits {
+    bool has_start;
+    bool has_end;
+};
+
+template <incrementable T, iota_traits Traits>
+struct iota_sequence_iface {
+    using cursor_type = T;
+
+    static constexpr bool is_infinite = !Traits.has_end;
+
+    static constexpr auto first(auto& self) -> cursor_type
+    {
+        if constexpr (Traits.has_start) {
+            return self.start_;
+        } else {
+            return cursor_type{};
+        }
+    }
+
+    static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+    {
+        if constexpr (Traits.has_end) {
+            return cur == self.end_;
+        } else {
+            return false;
+        }
+    }
+
+    static constexpr auto inc(auto&, cursor_type& cur) -> cursor_type&
+    {
+        return ++cur;
+    }
+
+    static constexpr auto read_at(auto&, cursor_type const& cur) -> T
+    {
+        return cur;
+    }
+
+    static constexpr auto last(auto& self) -> cursor_type
+        requires (Traits.has_end)
+    {
+        return self.end_;
+    }
+
+    static constexpr auto dec(auto&, cursor_type& cur) -> cursor_type&
+        requires decrementable<T>
+    {
+        return --cur;
+    }
+
+    static constexpr auto inc(auto&, cursor_type& cur, distance_t offset)
+        -> cursor_type&
+        requires advancable<T>
+    {
+        return cur += narrow_cast<std::iter_difference_t<T>>(offset);
+    }
+
+    static constexpr auto distance(auto&, cursor_type const& from, cursor_type const& to)
+        requires advancable<T>
+    {
+        return from <= to ? narrow_cast<distance_t>(to - from) : -narrow_cast<distance_t>(from - to);
+    }
+
+    static constexpr auto size(auto& self) -> distance_t
+        requires advancable<T> && (Traits.has_start && Traits.has_end)
+    {
+        return narrow_cast<distance_t>(self.end_ - self.start_);
+    }
+};
+
+template <typename T>
+struct basic_iota_sequence : lens_base<basic_iota_sequence<T>> {
+    using flux_sequence_iface = iota_sequence_iface<T, iota_traits{}>;
+    friend flux_sequence_iface;
+};
+
+template <typename T>
+struct iota_sequence : lens_base<iota_sequence<T>> {
+private:
+    T start_;
+
+    static constexpr iota_traits traits{.has_start = true};
+
+public:
+    constexpr explicit iota_sequence(T from)
+        : start_(std::move(from))
+    {}
+
+    using flux_sequence_iface = iota_sequence_iface<T, traits>;
+    friend flux_sequence_iface;
+};
+
+template <typename T>
+struct bounded_iota_sequence : lens_base<bounded_iota_sequence<T>> {
+    T start_;
+    T end_;
+
+    static constexpr iota_traits traits{.has_start = true, .has_end = true};
+
+public:
+    constexpr bounded_iota_sequence(T from, T to)
+        : start_(std::move(from)),
+          end_(std::move(to))
+    {}
+
+    using flux_sequence_iface = iota_sequence_iface<T, traits>;
+    friend flux_sequence_iface;
+};
+
+struct iota_fn {
+    template <incrementable T>
+    constexpr auto operator()(T from) const
+    {
+        return iota_sequence<T>(std::move(from));
+    }
+
+    template <incrementable T>
+    constexpr auto operator()(T from, T to) const
+    {
+        return bounded_iota_sequence<T>(std::move(from), std::move(to));
+    }
+};
+
+struct ints_fn {
+    constexpr auto operator()() const
+    {
+        return basic_iota_sequence<distance_t>();
+    }
+
+    constexpr auto operator()(distance_t from) const
+    {
+        return iota_sequence<distance_t>(from);
+    }
+
+    constexpr auto operator()(distance_t from, distance_t to) const
+    {
+        return bounded_iota_sequence<distance_t>(from, to);
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto iota = detail::iota_fn{};
+inline constexpr auto ints = detail::ints_fn{};
+
+} // namespace flux
+
+#endif // FLUX_SOURCE_IOTA_HPP_INCLUDED

--- a/include/flux/source/iota.hpp
+++ b/include/flux/source/iota.hpp
@@ -125,7 +125,7 @@ struct iota_sequence : lens_base<iota_sequence<T>> {
 private:
     T start_;
 
-    static constexpr iota_traits traits{.has_start = true};
+    static constexpr iota_traits traits{.has_start = true, .has_end = false};
 
 public:
     constexpr explicit iota_sequence(T from)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(test-libflux
     test_bitset.cpp
     test_empty.cpp
     test_getlines.cpp
+    test_iota.cpp
     test_istream.cpp
     test_istreambuf.cpp
     test_single.cpp

--- a/test/test_iota.cpp
+++ b/test/test_iota.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+#include <chrono>
+
+namespace {
+
+constexpr bool test_iota_basic()
+{
+    auto f = flux::ints();
+
+    using F = decltype(f);
+
+    static_assert(sizeof(f) == 1);
+    static_assert(flux::sequence<F>);
+    static_assert(flux::bidirectional_sequence<F>);
+    static_assert(flux::random_access_sequence<F>);
+    static_assert(flux::infinite_sequence<F>);
+    static_assert(not flux::bounded_sequence<F>);
+    static_assert(not flux::sized_sequence<F>);
+
+    STATIC_CHECK(check_equal(flux::take(f, 5), {0, 1, 2, 3, 4}));
+
+    return true;
+}
+static_assert(test_iota_basic());
+
+constexpr bool test_iota_from()
+{
+    auto f = flux::iota(1u);
+
+    using F = decltype(f);
+
+    static_assert(sizeof(f) == sizeof(unsigned));
+    static_assert(flux::sequence<F>);
+    static_assert(flux::bidirectional_sequence<F>);
+    static_assert(flux::random_access_sequence<F>);
+    static_assert(flux::infinite_sequence<F>);
+    static_assert(not flux::bounded_sequence<F>);
+    static_assert(not flux::sized_sequence<F>);
+
+    STATIC_CHECK(check_equal(flux::take(f, 5), {1u, 2u, 3u, 4u, 5u}));
+
+    return true;
+}
+static_assert(test_iota_from());
+
+constexpr bool test_iota_bounded()
+{
+    auto f = flux::iota(1u, 6u);
+
+    using F = decltype(f);
+
+    static_assert(flux::sequence<F>);
+    static_assert(flux::bidirectional_sequence<F>);
+    static_assert(flux::random_access_sequence<F>);
+    static_assert(not flux::infinite_sequence<F>);
+    static_assert(flux::bounded_sequence<F>);
+    static_assert(flux::sized_sequence<F>);
+
+    STATIC_CHECK(f.size() == 5);
+    STATIC_CHECK(check_equal(f, {1u, 2u, 3u, 4u, 5u}));
+
+    return true;
+}
+static_assert(test_iota_bounded());
+
+constexpr bool test_iota_custom_type()
+{
+    using namespace std::chrono_literals;
+
+    auto f = flux::iota(1s, 6s);
+
+    using F = decltype(f);
+
+    static_assert(flux::sequence<F>);
+    static_assert(flux::bidirectional_sequence<F>);
+    static_assert(not flux::random_access_sequence<F>); // no iter_difference_t
+    static_assert(not flux::infinite_sequence<F>);
+    static_assert(flux::bounded_sequence<F>);
+    static_assert(not flux::sized_sequence<F>); // !
+
+    STATIC_CHECK(f.count() == 5);
+    STATIC_CHECK(check_equal(f, {1s, 2s, 3s, 4s, 5s}));
+
+    return true;
+}
+static_assert(test_iota_custom_type());
+
+}
+
+TEST_CASE("iota")
+{
+    REQUIRE(test_iota_basic());
+    REQUIRE(test_iota_from());
+    REQUIRE(test_iota_bounded());
+    REQUIRE(test_iota_custom_type());
+}


### PR DESCRIPTION
A sequence of integers, how hard could it be?

Well, naming is an issue for a start. "Iota" comes in for criticism but it's been part of the STL for 25 years, and is also used in D and Go, so we'll stick with it (and we could hardly use Python's "range")

As far as the implementation goes, this is a bit simpler than Ranges' `views::iota` -- we don't have a custom difference type any more, and limits are handled a bit differently.