### PR TITLE
Add compare() algorithm

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -14,6 +14,7 @@
 #include <flux/op/cartesian_product.hpp>
 #include <flux/op/cartesian_product_with.hpp>
 #include <flux/op/chain.hpp>
+#include <flux/op/compare.hpp>
 #include <flux/op/count.hpp>
 #include <flux/op/drop.hpp>
 #include <flux/op/drop_while.hpp>

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -1,0 +1,57 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_COMPARE_HPP_INCLUDED
+#define FLUX_OP_COMPARE_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+#include <compare>
+
+namespace flux {
+
+namespace detail {
+
+template <typename Cmp>
+concept is_comparison_category =
+    std::same_as<Cmp, std::strong_ordering> ||
+    std::same_as<Cmp, std::weak_ordering> ||
+    std::same_as<Cmp, std::partial_ordering>;
+
+struct compare_fn {
+    template <sequence Seq1, sequence Seq2, typename Cmp = std::compare_three_way,
+              typename Proj1 = std::identity, typename Proj2 = std::identity>
+        requires std::invocable<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>> &&
+                 is_comparison_category<std::invoke_result_t<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>>>
+    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {},
+                              Proj1 proj1 = {}, Proj2 proj2 = {}) const
+        -> std::invoke_result_t<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>>
+    {
+        auto cur1 = flux::first(seq1);
+        auto cur2 = flux::first(seq2);
+
+        while (!flux::is_last(seq1, cur1) && !flux::is_last(seq2, cur2)) {
+            if (auto r = std::invoke(cmp, std::invoke(proj1, flux::unchecked_read_at(seq1, cur1)),
+                                       std::invoke(proj2, flux::unchecked_read_at(seq2, cur2))); r != 0) {
+                return r;
+            }
+            flux::inc(seq1, cur1);
+            flux::inc(seq2, cur2);
+        }
+
+        return !flux::is_last(seq1, cur1) ? std::strong_ordering::greater :
+               !flux::is_last(seq2, cur2) ? std::strong_ordering::less :
+                                           std::strong_ordering::equal;
+    }
+
+};
+
+} // namespace detail
+
+inline constexpr auto compare = detail::compare_fn{};
+
+} // namespace flux
+
+#endif // FLUX_OP_EQUAL_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(test-libflux
     test_cartesian_product_with.cpp
     test_chain.cpp
     test_contains.cpp
+    test_compare.cpp
     test_count.cpp
     test_count_if.cpp
     test_drop.cpp

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -1,0 +1,128 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+struct Test {
+    int i;
+
+    constexpr bool operator==(Test other) const { return i == other.i; }
+    constexpr bool operator<(Test other) const { return i < other.i; }
+};
+
+constexpr bool test_compare()
+{
+    // equal
+    {
+        std::array arr1{1, 2, 3, 4, 5};
+        int arr2[] = {1, 2, 3, 4, 5};
+
+        auto r = flux::compare(arr1, arr2);
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == 0);
+    }
+
+    // less
+    {
+        std::array arr1{1, 2, 3, 4, 0};
+        int arr2[] = {1, 2, 3, 4, 5};
+
+        auto r = flux::compare(arr1, arr2);
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::less);
+    }
+
+    // greater
+    {
+        std::array arr1{1., 2., 3., 4., 5.};
+        int arr2[] = {1, 2, 3, 4, 0};
+
+        auto r = flux::compare(arr1, arr2);
+        static_assert(std::same_as<decltype(r), std::partial_ordering>);
+        STATIC_CHECK(std::is_gt(r));
+    }
+
+    // LHS has fewer elements => less
+    {
+        std::string_view s1 = "abcd";
+        std::string_view s2 = "abcde";
+
+        auto r = flux::compare(s1, s2);
+
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r < 0);
+    }
+
+    // RHS has fewer elements => greater
+    {
+        std::string_view s1 = "abcde";
+        std::string_view s2 = "abcd";
+
+        auto r = flux::compare(s1, s2);
+
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r > 0);
+    }
+
+    // empty sequences are equal
+    {
+        // ...but still require the element types to be comparable
+        static_assert(not std::invocable<flux::detail::compare_fn, flux::detail::empty_sequence<int>, flux::detail::empty_sequence<std::nullptr_t>>);
+
+        auto r = flux::compare(flux::empty<int>, flux::empty<int>);
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::equal);
+    }
+
+    // can use custom comparator
+    {
+        std::array<Test, 3> arr1{Test{1}, {2}, {3}};
+        Test arr2[] = {{1}, {2}, {3}};
+
+        auto r = flux::compare(arr1, arr2, [](Test lhs, Test rhs) {
+            return lhs.i <=> rhs.i;
+        });
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::equal);
+    }
+
+    // Can use stdlib fallback fns for types with == and <
+    {
+        std::array<Test, 3> arr1{Test{1}, {2}, {3}};
+        Test arr2[] = {{1}, {2}, {3}};
+
+        auto r = flux::compare(arr1, arr2, std::compare_weak_order_fallback);
+        static_assert(std::same_as<decltype(r), std::weak_ordering>);
+        STATIC_CHECK(r == std::weak_ordering::equivalent);
+    }
+
+    // Can use projections
+    {
+        std::array<Test, 3> arr1{Test{1}, {2}, {3}};
+        Test arr2[] = {{1}, {2}, {3}};
+
+        auto r = flux::compare(arr1, arr2, {}, &Test::i, [](Test t) { return t.i; });
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::equal);
+    }
+
+    return true;
+}
+static_assert(test_compare());
+
+}
+
+TEST_CASE("compare")
+{
+    REQUIRE(test_compare());
+}


### PR DESCRIPTION
This performs three-way comparison of the elements of a pair of sequences, equivalent to `std::lexicographical_compare_three_way` (which might be the worst function name in the whole stdlib). The result type must be one of the three standard library comparison categories.

At the moment, as with `equal()`, there is only a free function `flux::compare()`, because I dislike the asymmetry of `lhs.compare(rhs)`. I might change my mind on this in future, especially given `std::string[_view]`  has a precisely equivalent `compare()` member.